### PR TITLE
Skip flaky test

### DIFF
--- a/tests/grub_cmd_set_date.in
+++ b/tests/grub_cmd_set_date.in
@@ -1,6 +1,9 @@
 #! /bin/bash
 set -e
 
+echo "Skipping flaky test."
+exit 77
+
 . "@builddir@/grub-core/modinfo.sh"
 
 case "${grub_modinfo_target_cpu}-${grub_modinfo_platform}" in


### PR DESCRIPTION
This test has been reported as flaky in the debian community, but there is as yet no fix from the upstream community. We should disable the test until we hear about a better solution.

http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3425/console