### PR TITLE
Fix use-after-free bug in probe_fs_envblk

### DIFF
--- a/util/grub-editenv.c
+++ b/util/grub-editenv.c
@@ -481,11 +481,6 @@ probe_fs_envblk (fs_envblk_spec_t *spec)
       grub_device_close (dev);
     }
 
-  free (grub_drives);
-  grub_gcry_fini_all ();
-  grub_fini_all ();
-  grub_util_biosdisk_fini ();
-
   for (p = spec; p->fs_name; p++)
     {
       if (strcmp (grub_fs->name, p->fs_name) == 0 && !have_abstraction)
@@ -496,9 +491,20 @@ probe_fs_envblk (fs_envblk_spec_t *spec)
 	  fs_envblk->fs = grub_fs;
 	  fs_envblk->data = p->fs_init (grub_dev);
 	  grub_device_close (grub_dev);
+
+	  free (grub_drives);
+	  grub_gcry_fini_all ();
+	  grub_fini_all ();
+	  grub_util_biosdisk_fini ();
+
 	  return fs_envblk;
 	}
     }
+
+  free (grub_drives);
+  grub_gcry_fini_all ();
+  grub_fini_all ();
+  grub_util_biosdisk_fini ();
 
   grub_device_close (grub_dev);
   return NULL;


### PR DESCRIPTION
This issue fixes DLPX-70063 core dumped when upgrade to trunk (6.1.0.0).  The segfault occurs in the grub_biosdisk logic when we call grub_zfs_init, because we attempt to read from a disk that has had its grub datastructures cleaned up. It's not entirely clear why this failure was only intermittent; probably it has to do with txgs syncing out, but anything else would be pure speculation.

Tested with ab-pre-push (http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3533/ , failure is environmental) and by running for several hours in a loop on a VM upgraded from 6.0 to trunk.