### PR TITLE
DLPX-71762 [Backport of DLPX-71746 to 6.0.5.0] delphix-bootcount service fails to start after upgrade

### DIFF
--- a/include/grub/util/libzfs.h
+++ b/include/grub/util/libzfs.h
@@ -47,6 +47,17 @@ extern int zpool_get_bootenv (zpool_handle_t *, char *, size_t, off_t);
 
 extern int libzfs_errno (libzfs_handle_t *);
 
+/*
+ * libzfs errors
+ */
+typedef enum zfs_error {
+	EZFS_SUCCESS = 0,	/* no error -- success */
+	EZFS_NOMEM = 2000,	/* out of memory */
+	EZFS_IOC_NOTSUPPORTED = 2079,  /* operation not supported by zfs module */
+	EZFS_REBUILDING,	/* resilvering (sequential reconstrution) */
+	EZFS_UNKNOWN = 2089
+} zfs_error_t;
+
 #endif /* ! HAVE_LIBZFS_H */
 
 libzfs_handle_t *grub_get_libzfs_handle (void);


### PR DESCRIPTION
https://github.com/delphix/grub2/pull/8 was erroneously merged into master instead of 6.0/stage. This PR is correctly targeted.