### PR TITLE
DLPX-73603 Grub should always default to the kernel version that comes with the active Delphix version

### DIFF
--- a/util/grub-mkconfig_lib.in
+++ b/util/grub-mkconfig_lib.in
@@ -295,8 +295,28 @@ version_test_gt ()
 
 version_find_latest ()
 {
+  #
+  # Delphix: we define the latest kernel version as the one listed in the
+  # package-list file of the delphix-entire package.
+  #
+  appliance_platform=$(cat /var/lib/delphix-appliance/platform)
+  if [ "x$appliance_platform" = "x" ]; then
+    echo "Error: file /var/lib/delphix-appliance/platform empty or missing" >&2
+    return 1
+  fi
+  delphix_pkgs_list="/usr/share/doc/delphix-entire-${appliance_platform}/packages.list.gz"
+  delphix_latest=$(zcat "$delphix_pkgs_list" | grep '^delphix-kernel-' | cut -d= -f1 | sed 's/delphix-kernel-//')
+  if [ "x$delphix_latest" = "x" ]; then
+    echo "Error: Failed to retrieve latest delphix-kernel version from '$delphix_pkgs_list'" >&2
+    return 1
+  fi
+
   version_find_latest_a=""
   for i in "$@" ; do
+    if echo "$i" | grep -q "$delphix_latest\$" ; then
+      echo "$i"
+      return
+    fi
     if version_test_gt "$i" "$version_find_latest_a" ; then
       version_find_latest_a="$i"
     fi


### PR DESCRIPTION
The "grub-mkconfig" utility is responsible for generating the "grub.cfg" configuration. It lists the kernel binaries installed on the system and generates entries in the grub menu for each kernel version. It also generates a "default" entry, which points to the latest kernel version. The "latest" kernel version is determined by doing a version string comparison of all the kernel versions.

The problem is that the "latest" kernel version as determined by string comparison will not necessarily coincide with the "latest" kernel version from the Delphix Engine's perspective. From the DE's perspective the "latest" kernel is the one that comes with the latest Delphix image, which might not necessarily have the highest numerical string. To figure out what is the latest kernel version, we must look at the "delphix-kernel" package name that is listedin the delphix-entire's package list at "/usr/share/doc/delphix-entire-*/packages.list.gz".

## Open question
Should we explicitly fail if `version_delphix_latest()` returns nothing?

## Testing
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4565/
- I've tested manually that the proper kernel version is being selected by simulating multiple kernel versions being installed. Grub looks at vmlinuz binaries in `/boot/vmlinuz-*` to determine which kernels are installed, so I just created some fake entries there with a higher version number and checked that the proper kernel version is selected by default by grub.
- TODO: test this in a real-life scenario by doing an upgrade to a Delphix image that has a lower kernel version string.