### PR TITLE
DLPX-73688 Recovery environment is unreachable

### DIFF
--- a/util/grub-mkconfig_lib.in
+++ b/util/grub-mkconfig_lib.in
@@ -298,7 +298,17 @@ version_find_latest ()
   #
   # Delphix: we define the latest kernel version as the one listed in the
   # package-list file of the delphix-entire package.
+  # Note that during initial image creation, we install the delphix-entire
+  # package at the end. If this command is invoked before that it would fail
+  # to query the package-list file. As a workaround, when there's only one
+  # kernel available, which would be the case during initial image creation, we
+  # return it directly.
   #
+  if [ "$#" -lt 2 ]; then
+    echo "$1"
+    return
+  fi
+
   appliance_platform=$(cat /var/lib/delphix-appliance/platform)
   if [ "x$appliance_platform" = "x" ]; then
     echo "Error: file /var/lib/delphix-appliance/platform empty or missing" >&2


### PR DESCRIPTION
Fixes regression introduced by #10.
See comments in-code for more details. Note that during upgrade we install the new `delphix-entire` package first, so the recovery environment will fetch the latest kernel; whether this is a good thing or a bad thing is debatable (i.e. it's nice to have the latest kernel, but latest kernel could potentially also cause boot issues which would affect both the recovery environment and the root environment.)

I've filed DLPX-74079 so that we can catch this kind of regressions earlier in the future.

## Testing
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4702
- Tested with Paul's help that the recovery environment works as expected