### PR TITLE
Merge master into 6.0/stage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -387,7 +387,7 @@ else
 fi
 
 # Check for functions and headers.
-AC_CHECK_FUNCS(posix_memalign memalign getextmntent)
+AC_CHECK_FUNCS(posix_memalign memalign getextmntent on_exit)
 AC_CHECK_HEADERS(sys/param.h sys/mount.h sys/mnttab.h limits.h)
 
 # glibc 2.25 still includes sys/sysmacros.h in sys/types.h but emits deprecation

--- a/debian/build-efi-images
+++ b/debian/build-efi-images
@@ -127,6 +127,7 @@ CD_MODULES="
 	test
 	true
 	video
+	xfs
 	zfs
 	zfscrypt
 	zfsinfo

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,49 @@
+grub2 (2.02-2ubuntu8.21) bionic; urgency=medium
+
+  * d/build-efi-images:
+    - Add xfs module to signed UEFI images
+      (Closes: #911147) (LP: #1652822)
+
+ -- Eric Desrochers <eric.desrochers@canonical.com>  Thu, 07 Jan 2021 08:45:31 -0500
+
+grub2 (2.02-2ubuntu8.20) bionic; urgency=medium
+
+  * Avoid "EFI stub: FIRMWARE BUG" message when booting >= 5.7 kernels
+    on arm64 by setting the image base address before jumping to the
+    PE/COFF entry point LP: #1900774
+  * Fix tftp timeouts when fetching large files. LP: #1900773
+
+ -- dann frazier <dannf@ubuntu.com>  Fri, 13 Nov 2020 17:40:19 -0700
+
+grub2 (2.02-2ubuntu8.19) bionic; urgency=medium
+
+  * grub-install: cherry-pick patch from grub-devel to make grub-install
+    fault tolerant. Create backup of files in /boot/grub, and restore them
+    on failure to complete grub-install. LP: #1891680
+    Also cherry-pick patch to make atexit work correctly.
+  * postinst.in: do not exit successfully when failing to show critical
+    grub-pc/install_devices_failed and grub-pc/install_devices_empty
+    prompts in non-interactive mode. This enables surfacing upgrade errors
+    to the users and/or automation. LP: #1891680 LP: #1896608
+  * postinst.in: do not attempt to call grub-install upon fresh install of
+    grub-pc because it it a job of installers to do that after fresh
+    install. Fixup for the issue unmasked by above. LP: #1891680
+  * postinst.in: Fixup postinst.in, to attempt grub-install upon explicit
+    dpkg-reconfigure grub-pc. LP: #1892526
+
+ -- Dimitri John Ledkov <xnox@ubuntu.com>  Thu, 22 Oct 2020 15:01:52 +0100
+
+grub2 (2.02-2ubuntu8.18) bionic; urgency=medium
+
+  * debian/patches/ubuntu-flavour-order.patch:
+    - Add a (hidden) GRUB_FLAVOUR_ORDER setting that can mark certain kernel
+      flavours as preferred, and specify an order between those preferred
+      flavours (LP: #1882663)
+  * debian/patches/ubuntu-recovery-dis_ucode_ldr.patch:
+    - Pass dis_ucode_ldr to kernel for recovery mode (LP: #1831789)
+
+ -- Julian Andres Klode <juliank@ubuntu.com>  Mon, 24 Aug 2020 10:45:45 +0200
+
 grub2 (2.02-2ubuntu8.17) bionic; urgency=medium
 
   * debian/postinst.in: Avoid calling grub-install on upgrade of the grub-pc

--- a/debian/patches/cherry-unix-exec-avoid-atexit-handlers-when-child-exits.patch
+++ b/debian/patches/cherry-unix-exec-avoid-atexit-handlers-when-child-exits.patch
@@ -1,0 +1,73 @@
+From e75cf4a58b5eaf482804e5e1b2cc7d4399df350e Mon Sep 17 00:00:00 2001
+From: Patrick Steinhardt <ps@pks.im>
+Date: Mon, 28 Aug 2017 20:57:19 +0200
+Subject: [PATCH] unix exec: avoid atexit handlers when child exits
+
+The `grub_util_exec_redirect_all` helper function can be used to
+spawn an executable and redirect its output to some files. After calling
+`fork()`, the parent will wait for the child to terminate with
+`waitpid()` while the child prepares its file descriptors, environment
+and finally calls `execvp()`. If something in the children's setup
+fails, it will stop by calling `exit(127)`.
+
+Calling `exit()` will cause any function registered via `atexit()` to be
+executed, which is usually the wrong thing to do in a child. And
+actually, one can easily observe faulty behaviour on musl-based systems
+without modprobe(8) installed: executing `grub-install --help` will call
+`grub_util_exec_redirect_all` with "modprobe", which obviously fails if
+modprobe(8) is not installed. Due to the child now exiting and invoking
+the `atexit()` handlers, it will clean up some data structures of the
+parent and cause it to be deadlocked in the `waitpid()` syscall.
+
+The issue can easily be fixed by calling `_exit(127)` instead, which is
+especially designed to be called when the atexit-handlers should not be
+executed.
+
+Signed-off-by: Patrick Steinhardt <ps@pks.im>
+---
+ grub-core/osdep/unix/exec.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/grub-core/osdep/unix/exec.c b/grub-core/osdep/unix/exec.c
+index 935ff120eb..db3259f650 100644
+--- a/grub-core/osdep/unix/exec.c
++++ b/grub-core/osdep/unix/exec.c
+@@ -99,7 +99,7 @@ grub_util_exec_redirect_all (const char *const *argv, const char *stdin_file,
+ 	{
+ 	  fd = open (stdin_file, O_RDONLY);
+ 	  if (fd < 0)
+-	    exit (127);
++	    _exit (127);
+ 	  dup2 (fd, STDIN_FILENO);
+ 	  close (fd);
+ 	}
+@@ -108,7 +108,7 @@ grub_util_exec_redirect_all (const char *const *argv, const char *stdin_file,
+ 	{
+ 	  fd = open (stdout_file, O_WRONLY | O_CREAT, 0700);
+ 	  if (fd < 0)
+-	    exit (127);
++	    _exit (127);
+ 	  dup2 (fd, STDOUT_FILENO);
+ 	  close (fd);
+ 	}
+@@ -117,7 +117,7 @@ grub_util_exec_redirect_all (const char *const *argv, const char *stdin_file,
+ 	{
+ 	  fd = open (stderr_file, O_WRONLY | O_CREAT, 0700);
+ 	  if (fd < 0)
+-	    exit (127);
++	    _exit (127);
+ 	  dup2 (fd, STDERR_FILENO);
+ 	  close (fd);
+ 	}
+@@ -126,7 +126,7 @@ grub_util_exec_redirect_all (const char *const *argv, const char *stdin_file,
+       setenv ("LC_ALL", "C", 1);
+ 
+       execvp ((char *) argv[0], (char **) argv);
+-      exit (127);
++      _exit (127);
+     }
+   waitpid (pid, &status, 0);
+   if (!WIFEXITED (status))
+-- 
+2.27.0
+

--- a/debian/patches/grub-install-backup-and-restore.patch
+++ b/debian/patches/grub-install-backup-and-restore.patch
@@ -1,0 +1,175 @@
+From 229c7f88463e2ae9fbb891a286cba50b580f7bad Mon Sep 17 00:00:00 2001
+From: Dimitri John Ledkov <xnox@ubuntu.com>
+Date: Wed, 19 Aug 2020 01:49:09 +0100
+Subject: grub-install: Add backup and restore
+
+Refactor clean_grub_dir to create a backup of all the files, instead
+of just irrevocably removing them as the first action. If available,
+register on_exit handle to restore the backup if any errors occur, or
+remove the backup if everything was successful. If on_exit is not
+available, the backup remains on disk for manual recovery.
+
+This allows safer upgrades of MBR & modules, such that
+modules/images/fonts/translations are consistent with MBR in case of
+errors. For example accidental grub-install /dev/non-existent-disk
+currently clobbers and upgrades modules in /boot/grub, despite not
+actually updating any MBR. This increases peak disk-usage slightly, by
+requiring temporarily twice the disk space to complete grub-install.
+
+Also add modinfo.sh to the cleanup/backup/restore codepath, to ensure
+it is also cleaned / backed up / restored.
+
+Signed-off-by: Dimitri John Ledkov <xnox@ubuntu.com>
+
+Patch-Name: grub-install-backup-and-restore.patch
+---
+ configure.ac               |   2 +-
+ util/grub-install-common.c | 105 +++++++++++++++++++++++++++++++------
+ 2 files changed, 91 insertions(+), 16 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 1819188f9f..6a88b9b0c0 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -420,7 +420,7 @@ else
+ fi
+ 
+ # Check for functions and headers.
+-AC_CHECK_FUNCS(posix_memalign memalign getextmntent)
++AC_CHECK_FUNCS(posix_memalign memalign getextmntent on_exit)
+ AC_CHECK_HEADERS(sys/param.h sys/mount.h sys/mnttab.h limits.h)
+ 
+ # glibc 2.25 still includes sys/sysmacros.h in sys/types.h but emits deprecation
+diff --git a/util/grub-install-common.c b/util/grub-install-common.c
+index 447504d3f4..a883b6daef 100644
+--- a/util/grub-install-common.c
++++ b/util/grub-install-common.c
+@@ -185,38 +185,113 @@ grub_install_mkdir_p (const char *dst)
+   free (t);
+ }
+ 
++static int
++strcmp_ext (const char *a, const char *b, const char *ext)
++{
++  char *bsuffix = grub_util_path_concat_ext (1, b, ext);
++  int r = strcmp (a, bsuffix);
++  free (bsuffix);
++  return r;
++}
++
++enum clean_grub_dir_mode
++{
++  CLEAN = 0,
++  CLEAN_BACKUP = 1,
++  CREATE_BACKUP = 2,
++  RESTORE_BACKUP = 3,
++};
++
+ static void
+-clean_grub_dir (const char *di)
++clean_grub_dir_real (const char *di, enum clean_grub_dir_mode mode)
+ {
+   grub_util_fd_dir_t d;
+   grub_util_fd_dirent_t de;
++  char suffix[2] = "";
++
++  if ((mode == CLEAN_BACKUP) || (mode == RESTORE_BACKUP))
++    {
++      strcpy (suffix, "-");
++    }
+ 
+   d = grub_util_fd_opendir (di);
+   if (!d)
+-    grub_util_error (_("cannot open directory `%s': %s"),
+-		     di, grub_util_fd_strerror ());
++    {
++      if (mode == CLEAN_BACKUP)
++	return;
++      grub_util_error (_("cannot open directory `%s': %s"),
++		       di, grub_util_fd_strerror ());
++    }
+ 
+   while ((de = grub_util_fd_readdir (d)))
+     {
+       const char *ext = strrchr (de->d_name, '.');
+-      if ((ext && (strcmp (ext, ".mod") == 0
+-		   || strcmp (ext, ".lst") == 0
+-		   || strcmp (ext, ".img") == 0
+-		   || strcmp (ext, ".mo") == 0)
+-	   && strcmp (de->d_name, "menu.lst") != 0)
+-	  || strcmp (de->d_name, "efiemu32.o") == 0
+-	  || strcmp (de->d_name, "efiemu64.o") == 0)
++      if ((ext && (strcmp_ext (ext, ".mod", suffix) == 0
++		   || strcmp_ext (ext, ".lst", suffix) == 0
++		   || strcmp_ext (ext, ".img", suffix) == 0
++		   || strcmp_ext (ext, ".mo", suffix) == 0)
++	   && strcmp_ext (de->d_name, "menu.lst", suffix) != 0)
++	  || strcmp_ext (de->d_name, "modinfo.sh", suffix) == 0
++	  || strcmp_ext (de->d_name, "efiemu32.o", suffix) == 0
++	  || strcmp_ext (de->d_name, "efiemu64.o", suffix) == 0)
+ 	{
+-	  char *x = grub_util_path_concat (2, di, de->d_name);
+-	  if (grub_util_unlink (x) < 0)
+-	    grub_util_error (_("cannot delete `%s': %s"), x,
+-			     grub_util_fd_strerror ());
+-	  free (x);
++	  char *srcf = grub_util_path_concat (2, di, de->d_name);
++
++	  if (mode == CREATE_BACKUP)
++	    {
++	      char *dstf = grub_util_path_concat_ext (2, di, de->d_name, "-");
++	      if (grub_util_rename (srcf, dstf) < 0)
++		grub_util_error (_("cannot backup `%s': %s"), srcf,
++				 grub_util_fd_strerror ());
++	      free (dstf);
++	    }
++	  else if (mode == RESTORE_BACKUP)
++	    {
++	      char *dstf = grub_util_path_concat_ext (2, di, de->d_name);
++	      dstf[strlen (dstf) - 1] = 0;
++	      if (grub_util_rename (srcf, dstf) < 0)
++		grub_util_error (_("cannot restore `%s': %s"), dstf,
++				 grub_util_fd_strerror ());
++	      free (dstf);
++	    }
++	  else
++	    {
++	      if (grub_util_unlink (srcf) < 0)
++		grub_util_error (_("cannot delete `%s': %s"), srcf,
++				 grub_util_fd_strerror ());
++	    }
++	  free (srcf);
+ 	}
+     }
+   grub_util_fd_closedir (d);
+ }
+ 
++static void
++restore_backup_on_exit (int status, void *arg)
++{
++  if (status == 0)
++    {
++      clean_grub_dir_real ((char *) arg, CLEAN_BACKUP);
++    }
++  else
++    {
++      clean_grub_dir_real ((char *) arg, CLEAN);
++      clean_grub_dir_real ((char *) arg, RESTORE_BACKUP);
++    }
++  free (arg);
++  arg = NULL;
++}
++
++static void
++clean_grub_dir (const char *di)
++{
++  clean_grub_dir_real (di, CLEAN_BACKUP);
++  clean_grub_dir_real (di, CREATE_BACKUP);
++#if defined(HAVE_ON_EXIT)
++  on_exit (restore_backup_on_exit, strdup (di));
++#endif
++}
++
+ struct install_list
+ {
+   int is_default;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -113,3 +113,9 @@ ubuntu-Update-the-linux-boot-protocol-version-check.patch
 0104-linux-loader-avoid-overflow-on-initrd-size-calculati.patch
 0105-linux-Fix-integer-overflows-in-initrd-size-handling.patch
 0106-efilinux-Fix-integer-overflows-in-grub_cmd_initrd.patch
+ubuntu-flavour-order.patch
+ubuntu-recovery-dis_ucode_ldr.patch
+cherry-unix-exec-avoid-atexit-handlers-when-child-exits.patch
+grub-install-backup-and-restore.patch
+ubuntu-linuxefi-arm64-set-base-addr.patch
+tftp-rollover-block-counter.patch

--- a/debian/patches/tftp-rollover-block-counter.patch
+++ b/debian/patches/tftp-rollover-block-counter.patch
@@ -1,0 +1,80 @@
+From b2bd086d143301c2d70529b2858d55de91fdbb31 Mon Sep 17 00:00:00 2001
+From: Javier Martinez Canillas <javierm@redhat.com>
+Date: Thu, 10 Sep 2020 17:17:57 +0200
+Subject: tftp: Roll-over block counter to prevent data packets timeouts
+
+Commit 781b3e5efc3 (tftp: Do not use priority queue) caused a regression
+when fetching files over TFTP whose size is bigger than 65535 * block size.
+
+  grub> linux /images/pxeboot/vmlinuz
+  grub> echo $?
+  0
+  grub> initrd /images/pxeboot/initrd.img
+  error: timeout reading '/images/pxeboot/initrd.img'.
+  grub> echo $?
+  28
+
+It is caused by the block number counter being a 16-bit field, which leads
+to a maximum file size of ((1 << 16) - 1) * block size. Because GRUB sets
+the block size to 1024 octets (by using the TFTP Blocksize Option from RFC
+2348 [0]), the maximum file size that can be transferred is 67107840 bytes.
+
+The TFTP PROTOCOL (REVISION 2) RFC 1350 [1] does not mention what a client
+should do when a file size is bigger than the maximum, but most TFTP hosts
+support the block number counter to be rolled over. That is, acking a data
+packet with a block number of 0 is taken as if the 65356th block was acked.
+
+It was working before because the block counter roll-over was happening due
+an overflow. But that got fixed by the mentioned commit, which led to the
+regression when attempting to fetch files larger than the maximum size.
+
+To allow TFTP file transfers of unlimited size again, re-introduce a block
+counter roll-over so the data packets are acked preventing the timeouts.
+
+[0]: https://tools.ietf.org/html/rfc2348
+[1]: https://tools.ietf.org/html/rfc1350
+
+Fixes: 781b3e5efc3 (tftp: Do not use priority queue)
+
+Suggested-by: Peter Jones <pjones@redhat.com>
+Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/1900773
+Origin: upstream, https://git.savannah.gnu.org/cgit/grub.git/commit/?id=a6838bbc6726ad624bd2b94991f690b8e9d23c69
+Last-Updated: 2020-11-09
+Patch-Name: tftp-rollover-block-counter.patch
+---
+ grub-core/net/tftp.c | 17 ++++++++++++++---
+ 1 file changed, 14 insertions(+), 3 deletions(-)
+
+diff --git a/grub-core/net/tftp.c b/grub-core/net/tftp.c
+index e6566fa17..33c0b8214 100644
+--- a/grub-core/net/tftp.c
++++ b/grub-core/net/tftp.c
+@@ -183,11 +183,22 @@ tftp_receive (grub_net_udp_socket_t sock __attribute__ ((unused)),
+ 	  return GRUB_ERR_NONE;
+ 	}
+ 
+-      /* Ack old/retransmitted block. */
+-      if (grub_be_to_cpu16 (tftph->u.data.block) < data->block + 1)
++      /*
++       * Ack old/retransmitted block.
++       *
++       * The block number is a 16-bit counter, thus the maximum file size that
++       * could be transfered is 65535 * block size. Most TFTP hosts support to
++       * roll-over the block counter to allow unlimited transfer file size.
++       *
++       * This behavior is not defined in the RFC 1350 [0] but is implemented by
++       * most TFTP clients and hosts.
++       *
++       * [0]: https://tools.ietf.org/html/rfc1350
++       */
++      if (grub_be_to_cpu16 (tftph->u.data.block) < ((grub_uint16_t) (data->block + 1)))
+ 	ack (data, grub_be_to_cpu16 (tftph->u.data.block));
+       /* Ignore unexpected block. */
+-      else if (grub_be_to_cpu16 (tftph->u.data.block) > data->block + 1)
++      else if (grub_be_to_cpu16 (tftph->u.data.block) > ((grub_uint16_t) (data->block + 1)))
+ 	grub_dprintf ("tftp", "TFTP unexpected block # %d\n", tftph->u.data.block);
+       else
+ 	{

--- a/debian/patches/ubuntu-flavour-order.patch
+++ b/debian/patches/ubuntu-flavour-order.patch
@@ -1,0 +1,57 @@
+From 2d236733ca4d74521cefab7fbf5e0f00967a028b Mon Sep 17 00:00:00 2001
+From: Julian Andres Klode <julian.klode@canonical.com>
+Date: Tue, 9 Jun 2020 11:50:23 +0200
+Subject: UBUNTU: Add GRUB_FLAVOUR_ORDER configuration item
+
+This allows you to specify flavours that will be preferred
+over other ones, and the order in which they are preferred
+- items in the list win over items not in the list, and items
+earlier in the list win over later ones.
+
+We still have to sort out storage of this, as we need to
+inject that from packages or the UA client and similar,
+and we can't just modify /etc/default/grub for that.
+
+LP: #1882663
+Patch-Name: ubuntu-flavour-order.patch
+---
+ util/grub-mkconfig.in     |  3 ++-
+ util/grub-mkconfig_lib.in | 15 +++++++++++++++
+ 2 files changed, 17 insertions(+), 1 deletion(-)
+
+--- a/util/grub-mkconfig.in
++++ b/util/grub-mkconfig.in
+@@ -249,7 +249,8 @@ export GRUB_DEFAULT \
+   GRUB_RECORDFAIL_TIMEOUT \
+   GRUB_RECOVERY_TITLE \
+   GRUB_FORCE_PARTUUID \
+-  GRUB_DISABLE_INITRD
++  GRUB_DISABLE_INITRD \
++  GRUB_FLAVOUR_ORDER
+ 
+ if test "x${grub_cfg}" != "x"; then
+   rm -f "${grub_cfg}.new"
+--- a/util/grub-mkconfig_lib.in
++++ b/util/grub-mkconfig_lib.in
+@@ -269,6 +269,21 @@ version_test_gt ()
+   if [ "x$version_test_gt_b" = "x" ] ; then
+     return 0
+   fi
++
++  # GRUB_FLAVOUR_ORDER is an ordered list of kernels, in decreasing
++  # priority. Any items in the list take precedence over other kernels,
++  # and earlier flavours are preferred over later ones.
++  for flavour in ${GRUB_FLAVOUR_ORDER:-}; do
++    version_test_gt_a_preferred=$(echo "$version_test_gt_a" | grep --  "-[0-9]*-$flavour\$")
++    version_test_gt_b_preferred=$(echo "$version_test_gt_b" | grep --  "-[0-9]*-$flavour\$")
++
++    if [ -n "$version_test_gt_a_preferred" -a -z "$version_test_gt_b_preferred" ] ; then
++      return 0
++    elif [ -z "$version_test_gt_a_preferred" -a -n "$version_test_gt_b_preferred" ] ; then
++      return 1
++    fi
++  done
++
+   case "$version_test_gt_a:$version_test_gt_b" in
+     *.old:*.old) ;;
+     *.old:*) version_test_gt_a="`echo "$version_test_gt_a" | sed -e 's/\.old$//'`" ; version_test_gt_cmp=gt ;;

--- a/debian/patches/ubuntu-linuxefi-arm64-set-base-addr.patch
+++ b/debian/patches/ubuntu-linuxefi-arm64-set-base-addr.patch
@@ -1,0 +1,68 @@
+From 3c882239552fa5b95e767403b0fd229967ff5263 Mon Sep 17 00:00:00 2001
+From: Javier Martinez Canillas <javierm@redhat.com>
+Date: Thu, 23 Apr 2020 15:06:46 +0200
+Subject: efi: Set image base address before jumping to the PE/COFF entry point
+
+Upstream GRUB uses the EFI LoadImage() and StartImage() to boot the Linux
+kernel. But our custom EFI loader that supports Secure Boot instead uses
+the EFI handover protocol (for x86) or jumping directly to the PE/COFF
+entry point (for aarch64).
+
+This is done to allow the bootloader to verify the images using the shim
+lock protocol to avoid booting untrusted binaries.
+
+Since the bootloader loads the kernel from the boot media instead of using
+LoadImage(), it is responsible to set the Loaded Image base address before
+booting the kernel.
+
+Otherwise the kernel EFI stub will complain that it was not set correctly
+and print the following warning message:
+
+EFI stub: ERROR: FIRMWARE BUG: efi_loaded_image_t::image_base has bogus value
+
+Resolves: rhbz#1825411
+
+Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>
+[ dannf: Offset adjustment to apply to Ubuntu's GRUB ]
+
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/1900774
+Origin: https://github.com/rhboot/grub2/commit/1d5ef08216edec4d31d0e10cfdb30b5ebfef7a45
+Last-Updated: 2020-11-09
+Patch-Name: ubuntu-linuxefi-arm64-set-base-addr.patch
+---
+ grub-core/loader/efi/linux.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/grub-core/loader/efi/linux.c b/grub-core/loader/efi/linux.c
+index f6d30bcf7..a09479cd6 100644
+--- a/grub-core/loader/efi/linux.c
++++ b/grub-core/loader/efi/linux.c
+@@ -72,6 +72,7 @@ grub_err_t
+ grub_efi_linux_boot (void *kernel_addr, grub_off_t handover_offset,
+ 		     void *kernel_params)
+ {
++  grub_efi_loaded_image_t *loaded_image = NULL;
+   handover_func hf;
+   int offset = 0;
+ 
+@@ -80,6 +81,20 @@ grub_efi_linux_boot (void *kernel_addr, grub_off_t handover_offset,
+   offset = 512;
+ #endif
+ 
++  /*
++   * Since the EFI loader is not calling the LoadImage() and StartImage()
++   * services for loading the kernel and booting respectively, it has to
++   * set the Loaded Image base address.
++   */
++  loaded_image = grub_efi_get_loaded_image (grub_efi_image_handle);
++  if (loaded_image)
++    loaded_image->image_base = kernel_addr;
++  else
++    grub_dprintf ("linux", "Loaded Image base address could not be set\n");
++
++  grub_dprintf ("linux", "kernel_addr: %p handover_offset: %p params: %p\n",
++		kernel_addr, (void *)(grub_efi_uintn_t)handover_offset, kernel_params);
++
+   hf = (handover_func)((char *)kernel_addr + handover_offset + offset);
+   hf (grub_efi_image_handle, grub_efi_system_table, kernel_params);
+ 

--- a/debian/patches/ubuntu-recovery-dis_ucode_ldr.patch
+++ b/debian/patches/ubuntu-recovery-dis_ucode_ldr.patch
@@ -1,0 +1,33 @@
+From 8052bb59dd6b89c8937afcf9000c4c13a82acc8f Mon Sep 17 00:00:00 2001
+From: Julian Andres Klode <julian.klode@canonical.com>
+Date: Fri, 19 Jun 2020 12:57:19 +0200
+Subject: Pass dis_ucode_ldr to kernel for recovery mode
+
+In case of a botched microcode update, this allows people to
+easily roll back.
+
+It will of course break in the more unlikely event that you are
+missing a microcode update in your firmware that is needed to boot
+the system, but editing the entry to remove an option is easier than
+having to figure out the option and add it.
+
+LP: #1831789
+Patch-Name: ubuntu-recovery-dis_ucode_ldr.patch
+---
+ util/grub.d/10_linux.in     |  4 ++++
+ util/grub.d/10_linux_zfs.in | 24 +++++++++++++++---------
+ 2 files changed, 19 insertions(+), 9 deletions(-)
+
+--- a/util/grub.d/10_linux.in
++++ b/util/grub.d/10_linux.in
+@@ -228,6 +228,10 @@ case "$machine" in
+     *) GENKERNEL_ARCH="$machine" ;;
+ esac
+ 
++case "$GENKERNEL_ARCH" in
++  x86*) GRUB_CMDLINE_LINUX_RECOVERY="$GRUB_CMDLINE_LINUX_RECOVERY dis_ucode_ldr";;
++esac
++
+ prepare_boot_cache=
+ prepare_root_cache=
+ boot_device_id=

--- a/debian/postinst.in
+++ b/debian/postinst.in
@@ -540,11 +540,11 @@ case "$1" in
         elif running_in_container; then
           # Skip grub-install in containers.
           :
-        elif dpkg --compare-versions "$2" ge 2.02-2ubuntu8; then
+        elif dpkg --compare-versions "$2" ge 2.02-2ubuntu8 && [ -z "$DEBCONF_RECONFIGURE" ]; then
           # Avoid the possibility of breaking grub on SRU update
           # due to ABI change
           :
-        elif test -z "$2" || test -e /boot/grub/core.img || \
+        elif test -e /boot/grub/core.img || \
              test -e /boot/grub/@FIRST_CPU_PLATFORM@/core.img || \
              test "$UPGRADE_FROM_GRUB_LEGACY" || test "$wubi_device"; then
           question=grub-pc/install_devices
@@ -715,7 +715,7 @@ case "$1" in
                     continue
                   fi
                 else
-                  break # noninteractive
+                  exit 1 # noninteractive
                 fi
               fi
             fi
@@ -738,7 +738,14 @@ case "$1" in
                   db_fset grub-pc/install_devices_empty seen false
                 fi
               else
-                break # noninteractive
+                # if question was seen we are done
+                # Otherwise, abort
+                db_fget grub-pc/install_devices_empty seen
+                if [ "$RET" = true ]; then
+                  break
+                else
+                  exit 1
+                fi
               fi
             else
               break

--- a/grub-core/loader/efi/linux.c
+++ b/grub-core/loader/efi/linux.c
@@ -70,12 +70,27 @@ grub_err_t
 grub_efi_linux_boot (void *kernel_addr, grub_off_t handover_offset,
 		     void *kernel_params)
 {
+  grub_efi_loaded_image_t *loaded_image = NULL;
   handover_func hf;
   int offset = 0;
 
 #ifdef __x86_64__
   offset = 512;
 #endif
+
+  /*
+   * Since the EFI loader is not calling the LoadImage() and StartImage()
+   * services for loading the kernel and booting respectively, it has to
+   * set the Loaded Image base address.
+   */
+  loaded_image = grub_efi_get_loaded_image (grub_efi_image_handle);
+  if (loaded_image)
+    loaded_image->image_base = kernel_addr;
+  else
+    grub_dprintf ("linux", "Loaded Image base address could not be set\n");
+
+  grub_dprintf ("linux", "kernel_addr: %p handover_offset: %p params: %p\n",
+		kernel_addr, (void *)(grub_efi_uintn_t)handover_offset, kernel_params);
 
   hf = (handover_func)((char *)kernel_addr + handover_offset + offset);
   hf (grub_efi_image_handle, grub_efi_system_table, kernel_params);

--- a/grub-core/osdep/unix/exec.c
+++ b/grub-core/osdep/unix/exec.c
@@ -99,7 +99,7 @@ grub_util_exec_redirect_all (const char *const *argv, const char *stdin_file,
 	{
 	  fd = open (stdin_file, O_RDONLY);
 	  if (fd < 0)
-	    exit (127);
+	    _exit (127);
 	  dup2 (fd, STDIN_FILENO);
 	  close (fd);
 	}
@@ -108,7 +108,7 @@ grub_util_exec_redirect_all (const char *const *argv, const char *stdin_file,
 	{
 	  fd = open (stdout_file, O_WRONLY | O_CREAT, 0700);
 	  if (fd < 0)
-	    exit (127);
+	    _exit (127);
 	  dup2 (fd, STDOUT_FILENO);
 	  close (fd);
 	}
@@ -117,7 +117,7 @@ grub_util_exec_redirect_all (const char *const *argv, const char *stdin_file,
 	{
 	  fd = open (stderr_file, O_WRONLY | O_CREAT, 0700);
 	  if (fd < 0)
-	    exit (127);
+	    _exit (127);
 	  dup2 (fd, STDERR_FILENO);
 	  close (fd);
 	}
@@ -126,7 +126,7 @@ grub_util_exec_redirect_all (const char *const *argv, const char *stdin_file,
       setenv ("LC_ALL", "C", 1);
 
       execvp ((char *) argv[0], (char **) argv);
-      exit (127);
+      _exit (127);
     }
   waitpid (pid, &status, 0);
   if (!WIFEXITED (status))

--- a/util/grub-install-common.c
+++ b/util/grub-install-common.c
@@ -179,36 +179,111 @@ grub_install_mkdir_p (const char *dst)
   free (t);
 }
 
+static int
+strcmp_ext (const char *a, const char *b, const char *ext)
+{
+  char *bsuffix = grub_util_path_concat_ext (1, b, ext);
+  int r = strcmp (a, bsuffix);
+  free (bsuffix);
+  return r;
+}
+
+enum clean_grub_dir_mode
+{
+  CLEAN = 0,
+  CLEAN_BACKUP = 1,
+  CREATE_BACKUP = 2,
+  RESTORE_BACKUP = 3,
+};
+
 static void
-clean_grub_dir (const char *di)
+clean_grub_dir_real (const char *di, enum clean_grub_dir_mode mode)
 {
   grub_util_fd_dir_t d;
   grub_util_fd_dirent_t de;
+  char suffix[2] = "";
+
+  if ((mode == CLEAN_BACKUP) || (mode == RESTORE_BACKUP))
+    {
+      strcpy (suffix, "-");
+    }
 
   d = grub_util_fd_opendir (di);
   if (!d)
-    grub_util_error (_("cannot open directory `%s': %s"),
-		     di, grub_util_fd_strerror ());
+    {
+      if (mode == CLEAN_BACKUP)
+	return;
+      grub_util_error (_("cannot open directory `%s': %s"),
+		       di, grub_util_fd_strerror ());
+    }
 
   while ((de = grub_util_fd_readdir (d)))
     {
       const char *ext = strrchr (de->d_name, '.');
-      if ((ext && (strcmp (ext, ".mod") == 0
-		   || strcmp (ext, ".lst") == 0
-		   || strcmp (ext, ".img") == 0
-		   || strcmp (ext, ".mo") == 0)
-	   && strcmp (de->d_name, "menu.lst") != 0)
-	  || strcmp (de->d_name, "efiemu32.o") == 0
-	  || strcmp (de->d_name, "efiemu64.o") == 0)
+      if ((ext && (strcmp_ext (ext, ".mod", suffix) == 0
+		   || strcmp_ext (ext, ".lst", suffix) == 0
+		   || strcmp_ext (ext, ".img", suffix) == 0
+		   || strcmp_ext (ext, ".mo", suffix) == 0)
+	   && strcmp_ext (de->d_name, "menu.lst", suffix) != 0)
+	  || strcmp_ext (de->d_name, "modinfo.sh", suffix) == 0
+	  || strcmp_ext (de->d_name, "efiemu32.o", suffix) == 0
+	  || strcmp_ext (de->d_name, "efiemu64.o", suffix) == 0)
 	{
-	  char *x = grub_util_path_concat (2, di, de->d_name);
-	  if (grub_util_unlink (x) < 0)
-	    grub_util_error (_("cannot delete `%s': %s"), x,
-			     grub_util_fd_strerror ());
-	  free (x);
+	  char *srcf = grub_util_path_concat (2, di, de->d_name);
+
+	  if (mode == CREATE_BACKUP)
+	    {
+	      char *dstf = grub_util_path_concat_ext (2, di, de->d_name, "-");
+	      if (grub_util_rename (srcf, dstf) < 0)
+		grub_util_error (_("cannot backup `%s': %s"), srcf,
+				 grub_util_fd_strerror ());
+	      free (dstf);
+	    }
+	  else if (mode == RESTORE_BACKUP)
+	    {
+	      char *dstf = grub_util_path_concat_ext (2, di, de->d_name);
+	      dstf[strlen (dstf) - 1] = 0;
+	      if (grub_util_rename (srcf, dstf) < 0)
+		grub_util_error (_("cannot restore `%s': %s"), dstf,
+				 grub_util_fd_strerror ());
+	      free (dstf);
+	    }
+	  else
+	    {
+	      if (grub_util_unlink (srcf) < 0)
+		grub_util_error (_("cannot delete `%s': %s"), srcf,
+				 grub_util_fd_strerror ());
+	    }
+	  free (srcf);
 	}
     }
   grub_util_fd_closedir (d);
+}
+
+static void
+restore_backup_on_exit (int status, void *arg)
+{
+  if (status == 0)
+    {
+      clean_grub_dir_real ((char *) arg, CLEAN_BACKUP);
+    }
+  else
+    {
+      clean_grub_dir_real ((char *) arg, CLEAN);
+      clean_grub_dir_real ((char *) arg, RESTORE_BACKUP);
+    }
+  free (arg);
+  arg = NULL;
+}
+
+static void
+clean_grub_dir (const char *di)
+{
+  clean_grub_dir_real (di, CLEAN_BACKUP);
+  clean_grub_dir_real (di, CREATE_BACKUP);
+#if defined(HAVE_ON_EXIT)
+  on_exit (restore_backup_on_exit, strdup (di));
+#endif
 }
 
 struct install_list

--- a/util/grub-mkconfig.in
+++ b/util/grub-mkconfig.in
@@ -249,7 +249,8 @@ export GRUB_DEFAULT \
   GRUB_RECORDFAIL_TIMEOUT \
   GRUB_RECOVERY_TITLE \
   GRUB_FORCE_PARTUUID \
-  GRUB_DISABLE_INITRD
+  GRUB_DISABLE_INITRD \
+  GRUB_FLAVOUR_ORDER
 
 if test "x${grub_cfg}" != "x"; then
   rm -f "${grub_cfg}.new"

--- a/util/grub-mkconfig_lib.in
+++ b/util/grub-mkconfig_lib.in
@@ -269,6 +269,21 @@ version_test_gt ()
   if [ "x$version_test_gt_b" = "x" ] ; then
     return 0
   fi
+
+  # GRUB_FLAVOUR_ORDER is an ordered list of kernels, in decreasing
+  # priority. Any items in the list take precedence over other kernels,
+  # and earlier flavours are preferred over later ones.
+  for flavour in ${GRUB_FLAVOUR_ORDER:-}; do
+    version_test_gt_a_preferred=$(echo "$version_test_gt_a" | grep --  "-[0-9]*-$flavour\$")
+    version_test_gt_b_preferred=$(echo "$version_test_gt_b" | grep --  "-[0-9]*-$flavour\$")
+
+    if [ -n "$version_test_gt_a_preferred" -a -z "$version_test_gt_b_preferred" ] ; then
+      return 0
+    elif [ -z "$version_test_gt_a_preferred" -a -n "$version_test_gt_b_preferred" ] ; then
+      return 1
+    fi
+  done
+
   case "$version_test_gt_a:$version_test_gt_b" in
     *.old:*.old) ;;
     *.old:*) version_test_gt_a="`echo "$version_test_gt_a" | sed -e 's/\.old$//'`" ; version_test_gt_cmp=gt ;;
@@ -280,8 +295,38 @@ version_test_gt ()
 
 version_find_latest ()
 {
+  #
+  # Delphix: we define the latest kernel version as the one listed in the
+  # package-list file of the delphix-entire package.
+  # Note that during initial image creation, we install the delphix-entire
+  # package at the end. If this command is invoked before that it would fail
+  # to query the package-list file. As a workaround, when there's only one
+  # kernel available, which would be the case during initial image creation, we
+  # return it directly.
+  #
+  if [ "$#" -lt 2 ]; then
+    echo "$1"
+    return
+  fi
+
+  appliance_platform=$(cat /var/lib/delphix-appliance/platform)
+  if [ "x$appliance_platform" = "x" ]; then
+    echo "Error: file /var/lib/delphix-appliance/platform empty or missing" >&2
+    return 1
+  fi
+  delphix_pkgs_list="/usr/share/doc/delphix-entire-${appliance_platform}/packages.list.gz"
+  delphix_latest=$(zcat "$delphix_pkgs_list" | grep '^delphix-kernel-' | cut -d= -f1 | sed 's/delphix-kernel-//')
+  if [ "x$delphix_latest" = "x" ]; then
+    echo "Error: Failed to retrieve latest delphix-kernel version from '$delphix_pkgs_list'" >&2
+    return 1
+  fi
+
   version_find_latest_a=""
   for i in "$@" ; do
+    if echo "$i" | grep -q "$delphix_latest\$" ; then
+      echo "$i"
+      return
+    fi
     if version_test_gt "$i" "$version_find_latest_a" ; then
       version_find_latest_a="$i"
     fi

--- a/util/grub.d/10_linux.in
+++ b/util/grub.d/10_linux.in
@@ -228,6 +228,10 @@ case "$machine" in
     *) GENKERNEL_ARCH="$machine" ;;
 esac
 
+case "$GENKERNEL_ARCH" in
+  x86*) GRUB_CMDLINE_LINUX_RECOVERY="$GRUB_CMDLINE_LINUX_RECOVERY dis_ucode_ldr";;
+esac
+
 prepare_boot_cache=
 prepare_root_cache=
 boot_device_id=


### PR DESCRIPTION
Note that although there's seemingly a lot of changes, this is not the case in reality and is due to https://github.com/delphix/grub2/pull/6.

The actual changes from upstream are fairly small:
```
Merge made by the 'recursive' strategy.
 configure.ac                                                                 |   2 +-
 debian/build-efi-images                                                      |   1 +
 debian/changelog                                                             |  46 +++++++++++++++++++++++++++++++++++++++++
 debian/patches/cherry-unix-exec-avoid-atexit-handlers-when-child-exits.patch |  73 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 debian/patches/grub-install-backup-and-restore.patch                         | 175 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 debian/patches/series                                                        |   6 ++++++
 debian/patches/tftp-rollover-block-counter.patch                             |  80 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 debian/patches/ubuntu-flavour-order.patch                                    |  57 +++++++++++++++++++++++++++++++++++++++++++++++++++
 debian/patches/ubuntu-linuxefi-arm64-set-base-addr.patch                     |  68 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 debian/patches/ubuntu-recovery-dis_ucode_ldr.patch                           |  33 ++++++++++++++++++++++++++++++
 debian/postinst.in                                                           |  15 ++++++++++----
 grub-core/loader/efi/linux.c                                                 |  15 ++++++++++++++
 grub-core/net/tftp.c                                                         |  17 ++++++++++++---
 grub-core/osdep/unix/exec.c                                                  |   8 ++++----
 util/grub-install-common.c                                                   | 105 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++--------------
 util/grub-mkconfig.in                                                        |   3 ++-
 util/grub-mkconfig_lib.in                                                    |  45 ++++++++++++++++++++++++++++++++++++++++
 util/grub.d/10_linux.in                                                      |   4 ++++
 18 files changed, 725 insertions(+), 28 deletions(-)
 create mode 100644 debian/patches/cherry-unix-exec-avoid-atexit-handlers-when-child-exits.patch
 create mode 100644 debian/patches/grub-install-backup-and-restore.patch
 create mode 100644 debian/patches/tftp-rollover-block-counter.patch
 create mode 100644 debian/patches/ubuntu-flavour-order.patch
 create mode 100644 debian/patches/ubuntu-linuxefi-arm64-set-base-addr.patch
 create mode 100644 debian/patches/ubuntu-recovery-dis_ucode_ldr.patch
```
This merge also backports 2 of our changes from master: 
 - #10 DLPX-73603 Grub should always default to the kernel version that comes with the active Delphix version
 - #12 DLPX-73688 Recovery environment is unreachable

## Testing
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4779/