### PR TITLE
DLPX-75315 [Backport of DLPX-73904 to 6.0.9.0] Add support for grub to read NVLIST formatted envblocks

### DIFF
--- a/grub-core/lib/envblk.c
+++ b/grub-core/lib/envblk.c
@@ -224,7 +224,7 @@ grub_envblk_delete (grub_envblk_t envblk, const char *name)
 }
 
 void
-grub_envblk_iterate (grub_envblk_t envblk,
+grub_envblk_iterate (const grub_envblk_t envblk,
                      void *hook_data,
                      int hook (const char *name, const char *value, void *hook_data))
 {

--- a/include/grub/util/libnvpair.h
+++ b/include/grub/util/libnvpair.h
@@ -27,11 +27,69 @@
 
 #include <stdio.h>	/* FILE */
 
+typedef enum {
+        DATA_TYPE_DONTCARE = -1,
+        DATA_TYPE_UNKNOWN = 0,
+        DATA_TYPE_BOOLEAN,
+	DATA_TYPE_BYTE,
+        DATA_TYPE_INT16,
+        DATA_TYPE_UINT16,
+	DATA_TYPE_INT32,
+        DATA_TYPE_UINT32,
+        DATA_TYPE_INT64,
+	DATA_TYPE_UINT64,
+        DATA_TYPE_STRING,
+        DATA_TYPE_BYTE_ARRAY,
+        DATA_TYPE_INT16_ARRAY,
+	DATA_TYPE_UINT16_ARRAY,
+        DATA_TYPE_INT32_ARRAY,
+        DATA_TYPE_UINT32_ARRAY,
+        DATA_TYPE_INT64_ARRAY,
+	DATA_TYPE_UINT64_ARRAY,
+        DATA_TYPE_STRING_ARRAY,
+        DATA_TYPE_HRTIME,
+	DATA_TYPE_NVLIST,
+        DATA_TYPE_NVLIST_ARRAY,
+        DATA_TYPE_BOOLEAN_VALUE,
+        DATA_TYPE_INT8,
+	DATA_TYPE_UINT8,
+        DATA_TYPE_BOOLEAN_ARRAY,
+        DATA_TYPE_INT8_ARRAY,
+#if !defined(_KERNEL) && !defined(_STANDALONE)
+        DATA_TYPE_UINT8_ARRAY,
+        DATA_TYPE_DOUBLE
+#else
+     	DATA_TYPE_UINT8_ARRAY
+#endif
+} data_type_t;
+
 typedef void nvlist_t;
+typedef void nvpair_t;
+
+/* nvlist pack encoding */
+#define NV_ENCODE_NATIVE        0
+#define NV_ENCODE_XDR           1
+
+/* nvlist persistent unique name flags, stored in nvl_nvflags */
+#define NV_UNIQUE_NAME          0x1
+#define NV_UNIQUE_NAME_TYPE     0x2
+
+int nvlist_alloc (nvlist_t **, unsigned int, int);
+void nvlist_free (nvlist_t *);
+int nvlist_size (nvlist_t *, size_t *, int);
 
 int nvlist_lookup_string (nvlist_t *, const char *, char **);
 int nvlist_lookup_nvlist (nvlist_t *, const char *, nvlist_t **);
 int nvlist_lookup_nvlist_array (nvlist_t *, const char *, nvlist_t ***, unsigned int *);
+int nvlist_lookup_uint64 (nvlist_t *, const char *, u_int64_t *);
+
+nvpair_t *nvlist_next_nvpair (nvlist_t *, nvpair_t *);
+char *nvpair_name (nvpair_t *);
+data_type_t nvpair_type (nvpair_t *);
+int nvpair_value_string (nvpair_t *, char **);
+
+int nvlist_add_string (nvlist_t *, const char *, const char *);
+int nvlist_add_uint64 (nvlist_t *, const char *, u_int64_t);
 
 #endif /* ! HAVE_LIBNVPAIR_H */
 

--- a/include/grub/util/libzfs.h
+++ b/include/grub/util/libzfs.h
@@ -42,8 +42,8 @@ extern nvlist_t *zpool_get_config (zpool_handle_t *, nvlist_t **);
 
 extern libzfs_handle_t *zpool_get_handle (zpool_handle_t *);
 
-extern int zpool_set_bootenv (zpool_handle_t *, const char *);
-extern int zpool_get_bootenv (zpool_handle_t *, char *, size_t, off_t);
+extern int zpool_set_bootenv (zpool_handle_t *, const nvlist_t*);
+extern int zpool_get_bootenv (zpool_handle_t *, nvlist_t **);
 
 extern int libzfs_errno (libzfs_handle_t *);
 


### PR DESCRIPTION
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5423/

Clean cherry-pick backport, above testing is combined with #16 