### PR TITLE
DLPX-76280 upgrade verify produces crash dump core.grub-editenv even even finished with error

### DIFF
--- a/util/grub-editenv.c
+++ b/util/grub-editenv.c
@@ -208,9 +208,8 @@ grub_zfs_get_bootenv (void *arg, char **buf, size_t *size)
   nvpair_t *nvp = NULL;
   size_t count;
   u_int64_t version;
-  if (error == -1)
+  if (error != 0)
     {
-      error = libzfs_errno (zpool_get_handle (zhp));
       return error;
     }
   nvlist_size (nvl, size, NV_ENCODE_NATIVE);
@@ -367,7 +366,7 @@ open_envblk (const char *name)
     return open_envblk_file(name);
 
   rc = fs_envblk->spec->fs_read(fs_envblk->data, &buf, &size);
-  if (rc < 0)
+  if (rc != 0)
     {
       grub_util_error (_("cannot read envblock: %s"), strerror (errno));
       return NULL;


### PR DESCRIPTION
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5681/console (in progress)

Manually tested by applying upgrade image and verifying no core dumps appeared

The crash was caused when an error value was returned from the zfs API as a result of the mismatch between the user and kernel code. The GRUB logic was supposed to gracefully handle that by simply returning, but it was checking for the wrong error value. As a result, we were proceeding with a NULL pointer, which immediately lead to the crash.