### PR TITLE
DLPX-76797 grub-initrd-fallback.service fails on Ubuntu 20.04

### DIFF
--- a/grub-initrd-fallback.service
+++ b/grub-initrd-fallback.service
@@ -8,6 +8,3 @@ Type=oneshot
 ExecStart=/usr/bin/grub-editenv /boot/grub/grubenv unset initrdfail
 ExecStart=/usr/bin/grub-editenv /boot/grub/grubenv unset prev_entry
 TimeoutSec=0
-
-[Install]
-WantedBy=multi-user.target rescue.target emergency.target


### PR DESCRIPTION
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5873/

Cloned a VM from the image created by that run, and verified that the grub-initrd-fallback service wasn't started, and so couldn't fail.