### PR TITLE
Merge

### DIFF
--- a/debian/.git-dpm
+++ b/debian/.git-dpm
@@ -1,9 +1,0 @@
-# see git-dpm(1) from git-dpm package
-23f42aa31bed9a6f44f840ea52f5f3e711c19fc0
-23f42aa31bed9a6f44f840ea52f5f3e711c19fc0
-578bb115fbd47e1c464696f1f8d6183e5443975d
-578bb115fbd47e1c464696f1f8d6183e5443975d
-grub2_2.04.orig.tar.xz
-3ed21de7be5970d7638b9f526bca3292af78e0fc
-6393864
-signature:d6df202a9bfa89abe2d7f288c1d438197c6f371a:833:grub2_2.04.orig.tar.xz.asc

--- a/debian/README.source
+++ b/debian/README.source
@@ -39,3 +39,6 @@ grub-team/grub uses git-dpm and contains the following branches:
 - pristine-tar:
 
   pritine-tar metadata based on upstream (not upstream).
+
+Ubuntu unapplies git-dpm patches, and instead uses gbp pq
+import|export --no-patch-numbers.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,33 @@
+grub2 (2.04-1ubuntu26.13) focal; urgency=medium
+
+  [ Julian Andres Klode ]
+  * unapply all patches, use gbp pq instead of git-dpm
+
+  [ Dimitri John Ledkov ]
+  * 10_linux: emit messages when initrdless boot is configured, attempted and
+    fails triggering fallback. LP: #1901553
+  * grub-common.service: port init.d script to systemd unit. Add warning
+    message, when initrdless boot fails triggering fallback. LP: #1901553
+  * debian/grub-common.service: change type to oneshot, add wantedby
+    sleep.target, after sleep.target. The service will now start after resume
+    from hybernation.  (LP: #1929860)
+  * grub-initrd-fallback.service: add wantedby sleep.target, after
+    sleep.target. The service will now start after resume from hybernation.
+    LP: #1929860
+  * grub-initrd-fallback.service, debian/grub-common.service: only start units
+    when booted with grub. Use presence of /boot/grub/grub.cfg as proxy. LP:
+    #1925507
+
+ -- Julian Andres Klode <juliank@ubuntu.com>  Thu, 12 Aug 2021 11:18:25 +0200
+
+grub2 (2.04-1ubuntu26.12) focal; urgency=medium
+
+  * Bump the version number in the replaces for grub-efi-* to account for
+    newer packages in bionic from grub2-unsigned shipping the kernel hook
+    conffiles.  LP: #1928674.
+
+ -- Steve Langasek <steve.langasek@ubuntu.com>  Wed, 19 May 2021 22:50:50 -0700
+
 grub2 (2.04-1ubuntu26.11) focal; urgency=medium
 
   [ Dimitri John Ledkov & Steve Langasek ]

--- a/debian/control
+++ b/debian/control
@@ -98,9 +98,9 @@ Package: grub2-common
 # of the package is not very useful in a utilities-only build.
 Architecture: any-i386 any-amd64 any-powerpc any-ppc64 any-ppc64el any-sparc any-sparc64 any-mipsel any-ia64 any-arm any-arm64
 Depends: grub-common (= ${binary:Version}), dpkg (>= 1.15.4) | install-info, ${shlibs:Depends}, ${misc:Depends}
-Replaces: grub, grub-legacy, ${legacy-doc-br}, grub-common (<< 1.99-1), grub-pc (<< 2.02+dfsg1-7), grub-coreboot (<< 2.02+dfsg1-7), grub-efi-ia32 (<< 2.02+dfsg1-7), grub-efi-amd64 (<< 2.02+dfsg1-7), grub-efi-ia64 (<< 2.02+dfsg1-7), grub-efi-arm (<< 2.02+dfsg1-7), grub-efi-arm64 (<< 2.02+dfsg1-7), grub-ieee1275 (<< 2.02+dfsg1-7), grub-uboot (<< 2.02+dfsg1-7), grub-xen (<< 2.02+dfsg1-7), grub-yeeloong (<< 2.02+dfsg1-7), grub-cloud-amd64 (<< 0.0.4)
+Replaces: grub, grub-legacy, ${legacy-doc-br}, grub-common (<< 1.99-1), grub-pc (<< 2.02+dfsg1-7), grub-coreboot (<< 2.02+dfsg1-7), grub-efi-ia32 (<< 2.02+dfsg1-7), grub-efi-amd64 (<< 2.04-1ubuntu44.2~), grub-efi-ia64 (<< 2.02+dfsg1-7), grub-efi-arm (<< 2.02+dfsg1-7), grub-efi-arm64 (<< 2.04-1ubuntu44.2~), grub-ieee1275 (<< 2.02+dfsg1-7), grub-uboot (<< 2.02+dfsg1-7), grub-xen (<< 2.02+dfsg1-7), grub-yeeloong (<< 2.02+dfsg1-7), grub-cloud-amd64 (<< 0.0.4)
 Conflicts: grub-legacy
-Breaks: grub (<< 0.97-54), ${legacy-doc-br}, shim (<< 13), grub-pc (<< 2.02+dfsg1-7), grub-coreboot (<< 2.02+dfsg1-7), grub-efi-ia32 (<< 2.02+dfsg1-7), grub-efi-amd64 (<< 2.02+dfsg1-7), grub-efi-ia64 (<< 2.02+dfsg1-7), grub-efi-arm (<< 2.02+dfsg1-7), grub-efi-arm64 (<< 2.02+dfsg1-7), grub-ieee1275 (<< 2.02+dfsg1-7), grub-uboot (<< 2.02+dfsg1-7), grub-xen (<< 2.02+dfsg1-7), grub-yeeloong (<< 2.02+dfsg1-7), grub-cloud-amd64 (<< 0.0.4)
+Breaks: grub (<< 0.97-54), ${legacy-doc-br}, shim (<< 13), grub-pc (<< 2.02+dfsg1-7), grub-coreboot (<< 2.02+dfsg1-7), grub-efi-ia32 (<< 2.02+dfsg1-7), grub-efi-amd64 (<< 2.04-1ubuntu44.2), grub-efi-ia64 (<< 2.02+dfsg1-7), grub-efi-arm (<< 2.02+dfsg1-7), grub-efi-arm64 (<< 2.04-1ubuntu44.2), grub-ieee1275 (<< 2.02+dfsg1-7), grub-uboot (<< 2.02+dfsg1-7), grub-xen (<< 2.02+dfsg1-7), grub-yeeloong (<< 2.02+dfsg1-7), grub-cloud-amd64 (<< 0.0.4)
 Multi-Arch: foreign
 Description: GRand Unified Bootloader (common files for version 2)
  This package contains common files shared by the distinct flavours of GRUB.

--- a/debian/grub-common.service
+++ b/debian/grub-common.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Record successful boot for GRUB
+After=sleep.target
+ConditionPathExists=/boot/grub/grub.cfg
+
+[Service]
+Type=oneshot
+Restart=no
+ExecStartPre=/bin/sh -c '[ -s /boot/grub/grubenv ] || rm -f /boot/grub/grubenv; mkdir -p /boot/grub'
+ExecStart=grub-editenv /boot/grub/grubenv unset recordfail
+ExecStartPost=/bin/sh -c 'if grub-editenv /boot/grub/grubenv list | grep -q initrdless_boot_fallback_triggered=1; then echo "grub: GRUB_FORCE_PARTUUID set, initrdless boot paniced, fallback triggered."; fi'
+StandardOutput=kmsg
+
+[Install]
+WantedBy=multi-user.target sleep.target

--- a/debian/patches/0074-uefi-firmware-rename-fwsetup-menuentry-to-UEFI-Firmw.patch
+++ b/debian/patches/0074-uefi-firmware-rename-fwsetup-menuentry-to-UEFI-Firmw.patch
@@ -1,4 +1,3 @@
-From 851928a168b66b14e5bfb771fe9e05a751188d45 Mon Sep 17 00:00:00 2001
 From: Dimitri John Ledkov <xnox@ubuntu.com>
 Date: Mon, 24 Feb 2020 20:29:53 +0000
 Subject: uefi-firmware: rename fwsetup menuentry to UEFI Firmware Settings
@@ -9,7 +8,7 @@ LP: #1864547
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/util/grub.d/30_uefi-firmware.in b/util/grub.d/30_uefi-firmware.in
-index 3c9f533d8..b072d219f 100644
+index 3c9f533..b072d21 100644
 --- a/util/grub.d/30_uefi-firmware.in
 +++ b/util/grub.d/30_uefi-firmware.in
 @@ -32,9 +32,9 @@ OsIndications="$efi_vars_dir/OsIndicationsSupported-$EFI_GLOBAL_VARIABLE/data"

--- a/debian/patches/0075-smbios-Add-a-linux-argument-to-apply-linux-modalias-.patch
+++ b/debian/patches/0075-smbios-Add-a-linux-argument-to-apply-linux-modalias-.patch
@@ -1,7 +1,7 @@
-From fc81f37515154ecdd7add783affb2ff91f2c6b14 Mon Sep 17 00:00:00 2001
 From: Julian Andres Klode <julian.klode@canonical.com>
 Date: Tue, 3 Mar 2020 16:06:34 +0100
-Subject: smbios: Add a --linux argument to apply linux modalias-like filtering
+Subject: smbios: Add a --linux argument to apply linux modalias-like
+ filtering
 
 Linux creates modalias strings by filtering out non-ASCII, space,
 and colon characters. Provide an option that does the same filtering
@@ -16,7 +16,7 @@ Origin: upstream, https://git.savannah.gnu.org/cgit/grub.git/commit/?id=87049f97
  1 file changed, 24 insertions(+)
 
 diff --git a/grub-core/commands/smbios.c b/grub-core/commands/smbios.c
-index 7a6a391fc..1a9086ddd 100644
+index 7a6a391..1a9086d 100644
 --- a/grub-core/commands/smbios.c
 +++ b/grub-core/commands/smbios.c
 @@ -64,6 +64,21 @@ grub_smbios_get_eps3 (void)

--- a/debian/patches/0076-ubuntu-Make-the-linux-command-in-EFI-grub-always-try.patch
+++ b/debian/patches/0076-ubuntu-Make-the-linux-command-in-EFI-grub-always-try.patch
@@ -1,4 +1,3 @@
-From 3221dd44405249694ca8583724e7f9a39afb3a13 Mon Sep 17 00:00:00 2001
 From: Chris Coulson <chris.coulson@canonical.com>
 Date: Wed, 11 Mar 2020 16:46:00 +0100
 Subject: ubuntu: Make the linux command in EFI grub always try EFI handover
@@ -13,12 +12,12 @@ builds, regardless of whether secure boot is enabled or not. This also allows
 a fallback to the non-EFI handover path on kernels that don't support it, but
 only if secure boot is disabled.
 ---
- grub-core/loader/i386/efi/linux.c | 14 +++++----
- grub-core/loader/i386/linux.c     | 47 +++++++++++++++++--------------
+ grub-core/loader/i386/efi/linux.c | 14 +++++++-----
+ grub-core/loader/i386/linux.c     | 47 ++++++++++++++++++++++-----------------
  2 files changed, 35 insertions(+), 26 deletions(-)
 
 diff --git a/grub-core/loader/i386/efi/linux.c b/grub-core/loader/i386/efi/linux.c
-index 6b6aef87f..fe3ca2c59 100644
+index 6b6aef8..fe3ca2c 100644
 --- a/grub-core/loader/i386/efi/linux.c
 +++ b/grub-core/loader/i386/efi/linux.c
 @@ -27,6 +27,7 @@
@@ -51,7 +50,7 @@ index 6b6aef87f..fe3ca2c59 100644
  
    params = grub_efi_allocate_pages_max (0x3fffffff,
 diff --git a/grub-core/loader/i386/linux.c b/grub-core/loader/i386/linux.c
-index 4328bcbdb..991eb29db 100644
+index 4328bcb..991eb29 100644
 --- a/grub-core/loader/i386/linux.c
 +++ b/grub-core/loader/i386/linux.c
 @@ -658,35 +658,40 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),

--- a/debian/patches/0077-ubuntu-Update-the-linux-boot-protocol-version-check.patch
+++ b/debian/patches/0077-ubuntu-Update-the-linux-boot-protocol-version-check.patch
@@ -1,4 +1,3 @@
-From 5c3a5aa3676d863f7bc6807000f940e4403dafab Mon Sep 17 00:00:00 2001
 From: Chris Coulson <chris.coulson@canonical.com>
 Date: Wed, 11 Mar 2020 16:46:41 +0100
 Subject: ubuntu: Update the linux boot protocol version check.
@@ -11,7 +10,7 @@ check accordingly.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/grub-core/loader/i386/efi/linux.c b/grub-core/loader/i386/efi/linux.c
-index fe3ca2c59..2929da7a2 100644
+index fe3ca2c..2929da7 100644
 --- a/grub-core/loader/i386/efi/linux.c
 +++ b/grub-core/loader/i386/efi/linux.c
 @@ -245,7 +245,7 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),

--- a/debian/patches/0081-yylex-Make-lexer-fatal-errors-actually-be-fatal.patch
+++ b/debian/patches/0081-yylex-Make-lexer-fatal-errors-actually-be-fatal.patch
@@ -1,4 +1,3 @@
-From a51348d877c031c065a0b3eff36b73487a115126 Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Wed, 15 Apr 2020 15:45:02 -0400
 Subject: yylex: Make lexer fatal errors actually be fatal
@@ -47,7 +46,7 @@ Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/grub-core/script/yylex.l b/grub-core/script/yylex.l
-index 7b44c37b7..b7203c823 100644
+index 7b44c37..b7203c8 100644
 --- a/grub-core/script/yylex.l
 +++ b/grub-core/script/yylex.l
 @@ -37,11 +37,11 @@

--- a/debian/patches/0082-safemath-Add-some-arithmetic-primitives-that-check-f.patch
+++ b/debian/patches/0082-safemath-Add-some-arithmetic-primitives-that-check-f.patch
@@ -1,4 +1,3 @@
-From a2bba5d8e79c68b37ce02a67c59c8c91436ea262 Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Mon, 15 Jun 2020 10:58:42 -0400
 Subject: safemath: Add some arithmetic primitives that check for overflow
@@ -25,7 +24,7 @@ Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
  create mode 100644 include/grub/safemath.h
 
 diff --git a/INSTALL b/INSTALL
-index 342c158e9..991479b52 100644
+index 342c158..991479b 100644
 --- a/INSTALL
 +++ b/INSTALL
 @@ -11,27 +11,9 @@ GRUB depends on some software packages installed into your system. If
@@ -59,7 +58,7 @@ index 342c158e9..991479b52 100644
  * GNU Bison 2.3 or later
  * GNU gettext 0.17 or later
 diff --git a/include/grub/compiler.h b/include/grub/compiler.h
-index c9e1d7a73..8f3be3ae7 100644
+index c9e1d7a..8f3be3a 100644
 --- a/include/grub/compiler.h
 +++ b/include/grub/compiler.h
 @@ -48,4 +48,12 @@
@@ -77,7 +76,7 @@ index c9e1d7a73..8f3be3ae7 100644
  #endif /* ! GRUB_COMPILER_HEADER */
 diff --git a/include/grub/safemath.h b/include/grub/safemath.h
 new file mode 100644
-index 000000000..c17b89bba
+index 0000000..c17b89b
 --- /dev/null
 +++ b/include/grub/safemath.h
 @@ -0,0 +1,37 @@

--- a/debian/patches/0083-calloc-Make-sure-we-always-have-an-overflow-checking.patch
+++ b/debian/patches/0083-calloc-Make-sure-we-always-have-an-overflow-checking.patch
@@ -1,4 +1,3 @@
-From 3fd721f1879461296edf784c71a9edda03fa81d6 Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Mon, 15 Jun 2020 12:15:29 -0400
 Subject: calloc: Make sure we always have an overflow-checking calloc()
@@ -12,17 +11,17 @@ it would occur.
 Signed-off-by: Peter Jones <pjones@redhat.com>
 Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
 ---
- grub-core/kern/emu/misc.c          | 12 +++++++++
- grub-core/kern/emu/mm.c            | 10 ++++++++
- grub-core/kern/mm.c                | 40 ++++++++++++++++++++++++++++++
- grub-core/lib/libgcrypt_wrap/mem.c | 11 ++++++--
- grub-core/lib/posix_wrap/stdlib.h  |  8 +++++-
+ grub-core/kern/emu/misc.c          | 12 ++++++++++++
+ grub-core/kern/emu/mm.c            | 10 ++++++++++
+ grub-core/kern/mm.c                | 40 ++++++++++++++++++++++++++++++++++++++
+ grub-core/lib/libgcrypt_wrap/mem.c | 11 +++++++++--
+ grub-core/lib/posix_wrap/stdlib.h  |  8 +++++++-
  include/grub/emu/misc.h            |  1 +
- include/grub/mm.h                  |  6 +++++
+ include/grub/mm.h                  |  6 ++++++
  7 files changed, 85 insertions(+), 3 deletions(-)
 
 diff --git a/grub-core/kern/emu/misc.c b/grub-core/kern/emu/misc.c
-index 65db79baa..dfd8a8ec4 100644
+index 65db79b..dfd8a8e 100644
 --- a/grub-core/kern/emu/misc.c
 +++ b/grub-core/kern/emu/misc.c
 @@ -85,6 +85,18 @@ grub_util_error (const char *fmt, ...)
@@ -45,7 +44,7 @@ index 65db79baa..dfd8a8ec4 100644
  xmalloc (grub_size_t size)
  {
 diff --git a/grub-core/kern/emu/mm.c b/grub-core/kern/emu/mm.c
-index f262e95e3..145b01d37 100644
+index f262e95..145b01d 100644
 --- a/grub-core/kern/emu/mm.c
 +++ b/grub-core/kern/emu/mm.c
 @@ -25,6 +25,16 @@
@@ -66,7 +65,7 @@ index f262e95e3..145b01d37 100644
  grub_malloc (grub_size_t size)
  {
 diff --git a/grub-core/kern/mm.c b/grub-core/kern/mm.c
-index ee88ff611..f2822a836 100644
+index ee88ff6..f2822a8 100644
 --- a/grub-core/kern/mm.c
 +++ b/grub-core/kern/mm.c
 @@ -67,8 +67,10 @@
@@ -133,7 +132,7 @@ index ee88ff611..f2822a836 100644
  grub_debug_malloc (const char *file, int line, grub_size_t size)
  {
 diff --git a/grub-core/lib/libgcrypt_wrap/mem.c b/grub-core/lib/libgcrypt_wrap/mem.c
-index beeb661a3..74c6eafe5 100644
+index beeb661..74c6eaf 100644
 --- a/grub-core/lib/libgcrypt_wrap/mem.c
 +++ b/grub-core/lib/libgcrypt_wrap/mem.c
 @@ -4,6 +4,7 @@
@@ -169,7 +168,7 @@ index beeb661a3..74c6eafe5 100644
      grub_fatal ("gcry_xcalloc failed");
    return ret;
 diff --git a/grub-core/lib/posix_wrap/stdlib.h b/grub-core/lib/posix_wrap/stdlib.h
-index 3b46f47ff..7a8d385e9 100644
+index 3b46f47..7a8d385 100644
 --- a/grub-core/lib/posix_wrap/stdlib.h
 +++ b/grub-core/lib/posix_wrap/stdlib.h
 @@ -21,6 +21,7 @@
@@ -195,7 +194,7 @@ index 3b46f47ff..7a8d385e9 100644
  
  static inline void *
 diff --git a/include/grub/emu/misc.h b/include/grub/emu/misc.h
-index ce464cfd0..ff9c48a64 100644
+index ce464cf..ff9c48a 100644
 --- a/include/grub/emu/misc.h
 +++ b/include/grub/emu/misc.h
 @@ -47,6 +47,7 @@ grub_util_device_is_mapped (const char *dev);
@@ -207,7 +206,7 @@ index ce464cfd0..ff9c48a64 100644
  void * EXPORT_FUNC(xrealloc) (void *ptr, grub_size_t size) WARN_UNUSED_RESULT;
  char * EXPORT_FUNC(xstrdup) (const char *str) WARN_UNUSED_RESULT;
 diff --git a/include/grub/mm.h b/include/grub/mm.h
-index 28e2e53eb..9c38dd3ca 100644
+index 28e2e53..9c38dd3 100644
 --- a/include/grub/mm.h
 +++ b/include/grub/mm.h
 @@ -29,6 +29,7 @@

--- a/debian/patches/0084-calloc-Use-calloc-at-most-places.patch
+++ b/debian/patches/0084-calloc-Use-calloc-at-most-places.patch
@@ -1,4 +1,3 @@
-From 28ae4d74249c555c45aa626be317ce285911391f Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Mon, 15 Jun 2020 12:26:01 -0400
 Subject: calloc: Use calloc() at most places
@@ -111,7 +110,7 @@ Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
  86 files changed, 176 insertions(+), 175 deletions(-)
 
 diff --git a/grub-core/bus/usb/usbhub.c b/grub-core/bus/usb/usbhub.c
-index 34a7ff1b5..a06cce302 100644
+index 34a7ff1..a06cce3 100644
 --- a/grub-core/bus/usb/usbhub.c
 +++ b/grub-core/bus/usb/usbhub.c
 @@ -149,8 +149,8 @@ grub_usb_add_hub (grub_usb_device_t dev)
@@ -137,7 +136,7 @@ index 34a7ff1b5..a06cce302 100644
      {
        grub_free (hub->devices);
 diff --git a/grub-core/commands/efi/lsefisystab.c b/grub-core/commands/efi/lsefisystab.c
-index 902788250..d29188efa 100644
+index 9027882..d29188e 100644
 --- a/grub-core/commands/efi/lsefisystab.c
 +++ b/grub-core/commands/efi/lsefisystab.c
 @@ -73,7 +73,8 @@ grub_cmd_lsefisystab (struct grub_command *cmd __attribute__ ((unused)),
@@ -151,7 +150,7 @@ index 902788250..d29188efa 100644
        return grub_errno;
      *grub_utf16_to_utf8 ((grub_uint8_t *) vendor, st->firmware_vendor,
 diff --git a/grub-core/commands/legacycfg.c b/grub-core/commands/legacycfg.c
-index db7a8f002..5e3ec0d5e 100644
+index db7a8f0..5e3ec0d 100644
 --- a/grub-core/commands/legacycfg.c
 +++ b/grub-core/commands/legacycfg.c
 @@ -314,7 +314,7 @@ grub_cmd_legacy_kernel (struct grub_command *mycmd __attribute__ ((unused)),
@@ -182,7 +181,7 @@ index db7a8f002..5e3ec0d5e 100644
  	return grub_errno;
        grub_memcpy (newargs + 1, args, argc * sizeof (newargs[0]));
 diff --git a/grub-core/commands/menuentry.c b/grub-core/commands/menuentry.c
-index 2c5363da7..9164df744 100644
+index 2c5363d..9164df7 100644
 --- a/grub-core/commands/menuentry.c
 +++ b/grub-core/commands/menuentry.c
 @@ -154,7 +154,7 @@ grub_normal_add_menu_entry (int argc, const char **args,
@@ -195,7 +194,7 @@ index 2c5363da7..9164df744 100644
      goto fail;
  
 diff --git a/grub-core/commands/nativedisk.c b/grub-core/commands/nativedisk.c
-index 699447d11..7c8f97f6a 100644
+index 699447d..7c8f97f 100644
 --- a/grub-core/commands/nativedisk.c
 +++ b/grub-core/commands/nativedisk.c
 @@ -195,7 +195,7 @@ grub_cmd_nativedisk (grub_command_t cmd __attribute__ ((unused)),
@@ -208,7 +207,7 @@ index 699447d11..7c8f97f6a 100644
      return grub_errno;
  
 diff --git a/grub-core/commands/parttool.c b/grub-core/commands/parttool.c
-index 22b46b187..051e31320 100644
+index 22b46b1..051e313 100644
 --- a/grub-core/commands/parttool.c
 +++ b/grub-core/commands/parttool.c
 @@ -59,7 +59,13 @@ grub_parttool_register(const char *part_name,
@@ -245,7 +244,7 @@ index 22b46b187..051e31320 100644
  	  if (! parsed[j])
  	    {
 diff --git a/grub-core/commands/regexp.c b/grub-core/commands/regexp.c
-index f00b184c8..4019164f3 100644
+index f00b184..4019164 100644
 --- a/grub-core/commands/regexp.c
 +++ b/grub-core/commands/regexp.c
 @@ -116,7 +116,7 @@ grub_cmd_regexp (grub_extcmd_context_t ctxt, int argc, char **args)
@@ -258,7 +257,7 @@ index f00b184c8..4019164f3 100644
      goto fail;
  
 diff --git a/grub-core/commands/search_wrap.c b/grub-core/commands/search_wrap.c
-index d7fd26b94..47fc8eb99 100644
+index d7fd26b..47fc8eb 100644
 --- a/grub-core/commands/search_wrap.c
 +++ b/grub-core/commands/search_wrap.c
 @@ -122,7 +122,7 @@ grub_cmd_search (grub_extcmd_context_t ctxt, int argc, char **args)
@@ -271,7 +270,7 @@ index d7fd26b94..47fc8eb99 100644
      return grub_errno;
    j = 0;
 diff --git a/grub-core/disk/diskfilter.c b/grub-core/disk/diskfilter.c
-index c3b578acf..68ca9e0be 100644
+index c3b578a..68ca9e0 100644
 --- a/grub-core/disk/diskfilter.c
 +++ b/grub-core/disk/diskfilter.c
 @@ -1134,7 +1134,7 @@ grub_diskfilter_make_raid (grub_size_t uuidlen, char *uuid, int nmemb,
@@ -293,7 +292,7 @@ index c3b578acf..68ca9e0be 100644
  	  for (p = disk->partition; p; p = p->parent)
  	    pv->partmaps[s++] = xstrdup (p->partmap->name);
 diff --git a/grub-core/disk/ieee1275/ofdisk.c b/grub-core/disk/ieee1275/ofdisk.c
-index f73257e66..03674cb47 100644
+index f73257e..03674cb 100644
 --- a/grub-core/disk/ieee1275/ofdisk.c
 +++ b/grub-core/disk/ieee1275/ofdisk.c
 @@ -297,7 +297,7 @@ dev_iterate (const struct grub_ieee1275_devalias *alias)
@@ -306,7 +305,7 @@ index f73257e66..03674cb47 100644
        if (!table)
          {
 diff --git a/grub-core/disk/ldm.c b/grub-core/disk/ldm.c
-index 2a22d2d6c..e6323701a 100644
+index 2a22d2d..e632370 100644
 --- a/grub-core/disk/ldm.c
 +++ b/grub-core/disk/ldm.c
 @@ -323,8 +323,8 @@ make_vg (grub_disk_t disk,
@@ -352,7 +351,7 @@ index 2a22d2d6c..e6323701a 100644
  	return grub_errno;
        for (i = 0; i < *nsectors; i++)
 diff --git a/grub-core/disk/luks.c b/grub-core/disk/luks.c
-index 86c50c612..18b3a8bb1 100644
+index 86c50c6..18b3a8b 100644
 --- a/grub-core/disk/luks.c
 +++ b/grub-core/disk/luks.c
 @@ -336,7 +336,7 @@ luks_recover_key (grub_disk_t source,
@@ -365,7 +364,7 @@ index 86c50c612..18b3a8bb1 100644
      return grub_errno;
  
 diff --git a/grub-core/disk/lvm.c b/grub-core/disk/lvm.c
-index 7b265c780..d1df640b3 100644
+index 7b265c7..d1df640 100644
 --- a/grub-core/disk/lvm.c
 +++ b/grub-core/disk/lvm.c
 @@ -173,7 +173,7 @@ grub_lvm_detect (grub_disk_t disk,
@@ -398,7 +397,7 @@ index 7b265c780..d1df640b3 100644
  
  		      p = grub_strstr (p, "stripes = [");
 diff --git a/grub-core/disk/xen/xendisk.c b/grub-core/disk/xen/xendisk.c
-index 48476cbbf..d6612eebd 100644
+index 48476cb..d6612ee 100644
 --- a/grub-core/disk/xen/xendisk.c
 +++ b/grub-core/disk/xen/xendisk.c
 @@ -426,7 +426,7 @@ grub_xendisk_init (void)
@@ -411,7 +410,7 @@ index 48476cbbf..d6612eebd 100644
      return;
    if (grub_xenstore_dir ("device/vbd", fill, &ctr))
 diff --git a/grub-core/efiemu/loadcore.c b/grub-core/efiemu/loadcore.c
-index 44085ef81..2b924623f 100644
+index 44085ef..2b92462 100644
 --- a/grub-core/efiemu/loadcore.c
 +++ b/grub-core/efiemu/loadcore.c
 @@ -201,7 +201,7 @@ grub_efiemu_count_symbols (const Elf_Ehdr *e)
@@ -424,7 +423,7 @@ index 44085ef81..2b924623f 100644
    /* Relocators */
    for (i = 0, s = (Elf_Shdr *) ((char *) e + e->e_shoff);
 diff --git a/grub-core/efiemu/mm.c b/grub-core/efiemu/mm.c
-index 52a032f7b..9b8e0d0ad 100644
+index 52a032f..9b8e0d0 100644
 --- a/grub-core/efiemu/mm.c
 +++ b/grub-core/efiemu/mm.c
 @@ -554,11 +554,11 @@ grub_efiemu_mmap_sort_and_uniq (void)
@@ -451,7 +450,7 @@ index 52a032f7b..9b8e0d0ad 100644
      {
        grub_efiemu_unload ();
 diff --git a/grub-core/font/font.c b/grub-core/font/font.c
-index 85a292557..8e118b315 100644
+index 85a2925..8e118b3 100644
 --- a/grub-core/font/font.c
 +++ b/grub-core/font/font.c
 @@ -293,8 +293,7 @@ load_font_index (grub_file_t file, grub_uint32_t sect_length, struct
@@ -465,7 +464,7 @@ index 85a292557..8e118b315 100644
      return 1;
    font->bmp_idx = grub_malloc (0x10000 * sizeof (grub_uint16_t));
 diff --git a/grub-core/fs/affs.c b/grub-core/fs/affs.c
-index 6b6a2bc91..220b3712f 100644
+index 6b6a2bc..220b371 100644
 --- a/grub-core/fs/affs.c
 +++ b/grub-core/fs/affs.c
 @@ -301,7 +301,7 @@ grub_affs_read_symlink (grub_fshelp_node_t node)
@@ -496,7 +495,7 @@ index 6b6a2bc91..220b3712f 100644
  	*grub_latin1_to_utf8 ((grub_uint8_t *) *label, file.name, len) = '\0';
      }
 diff --git a/grub-core/fs/btrfs.c b/grub-core/fs/btrfs.c
-index 48bd3d04a..11272efc1 100644
+index 48bd3d0..11272ef 100644
 --- a/grub-core/fs/btrfs.c
 +++ b/grub-core/fs/btrfs.c
 @@ -413,7 +413,7 @@ lower_bound (struct grub_btrfs_data *data,
@@ -527,7 +526,7 @@ index 48bd3d04a..11272efc1 100644
      return grub_errno;
    for (i = 0; i < *nsectors; i++)
 diff --git a/grub-core/fs/hfs.c b/grub-core/fs/hfs.c
-index ac0a40990..3fe842b4d 100644
+index ac0a409..3fe842b 100644
 --- a/grub-core/fs/hfs.c
 +++ b/grub-core/fs/hfs.c
 @@ -1360,7 +1360,7 @@ grub_hfs_label (grub_device_t device, char **label)
@@ -540,7 +539,7 @@ index ac0a40990..3fe842b4d 100644
  	macroman_to_utf8 (*label, data->sblock.volname + 1,
  			  len + 1, 0);
 diff --git a/grub-core/fs/hfsplus.c b/grub-core/fs/hfsplus.c
-index 54786bb1c..dae43becc 100644
+index 54786bb..dae43be 100644
 --- a/grub-core/fs/hfsplus.c
 +++ b/grub-core/fs/hfsplus.c
 @@ -720,7 +720,7 @@ list_nodes (void *record, void *hook_arg)
@@ -571,7 +570,7 @@ index 54786bb1c..dae43becc 100644
      {
        grub_free (label_name);
 diff --git a/grub-core/fs/iso9660.c b/grub-core/fs/iso9660.c
-index 49c0c632b..4f1b52a55 100644
+index 49c0c63..4f1b52a 100644
 --- a/grub-core/fs/iso9660.c
 +++ b/grub-core/fs/iso9660.c
 @@ -331,7 +331,7 @@ grub_iso9660_convert_string (grub_uint8_t *us, int len)
@@ -584,7 +583,7 @@ index 49c0c632b..4f1b52a55 100644
      return NULL;
  
 diff --git a/grub-core/fs/ntfs.c b/grub-core/fs/ntfs.c
-index fc4e1f678..2f34f76da 100644
+index fc4e1f6..2f34f76 100644
 --- a/grub-core/fs/ntfs.c
 +++ b/grub-core/fs/ntfs.c
 @@ -556,8 +556,8 @@ get_utf8 (grub_uint8_t *in, grub_size_t len)
@@ -599,7 +598,7 @@ index fc4e1f678..2f34f76da 100644
      {
        grub_free (buf);
 diff --git a/grub-core/fs/sfs.c b/grub-core/fs/sfs.c
-index 50c1fe72f..90f7fb379 100644
+index 50c1fe7..90f7fb3 100644
 --- a/grub-core/fs/sfs.c
 +++ b/grub-core/fs/sfs.c
 @@ -266,7 +266,7 @@ grub_sfs_read_block (grub_fshelp_node_t node, grub_disk_addr_t fileblock)
@@ -612,7 +611,7 @@ index 50c1fe72f..90f7fb379 100644
  	{
  	  grub_errno = 0;
 diff --git a/grub-core/fs/tar.c b/grub-core/fs/tar.c
-index 7d63e0c99..c551ed6b5 100644
+index 7d63e0c..c551ed6 100644
 --- a/grub-core/fs/tar.c
 +++ b/grub-core/fs/tar.c
 @@ -120,7 +120,7 @@ grub_cpio_find_file (struct grub_archelp_data *data, char **name,
@@ -625,7 +624,7 @@ index 7d63e0c99..c551ed6b5 100644
  		return grub_errno;
  	      grub_free (data->linkname);
 diff --git a/grub-core/fs/udf.c b/grub-core/fs/udf.c
-index dc8b6e2d1..a83761674 100644
+index dc8b6e2..a837616 100644
 --- a/grub-core/fs/udf.c
 +++ b/grub-core/fs/udf.c
 @@ -873,7 +873,7 @@ read_string (const grub_uint8_t *raw, grub_size_t sz, char *outbuf)
@@ -647,7 +646,7 @@ index dc8b6e2d1..a83761674 100644
  	return NULL;
        for (i = 0; i < utf16len; i++)
 diff --git a/grub-core/fs/zfs/zfs.c b/grub-core/fs/zfs/zfs.c
-index 2f72e42bf..381dde556 100644
+index 2f72e42..381dde5 100644
 --- a/grub-core/fs/zfs/zfs.c
 +++ b/grub-core/fs/zfs/zfs.c
 @@ -3325,7 +3325,7 @@ dnode_get_fullpath (const char *fullpath, struct subvolume *subvol,
@@ -669,7 +668,7 @@ index 2f72e42bf..381dde556 100644
      return grub_errno;
    for (i = 0; i < *nsectors; i++)
 diff --git a/grub-core/gfxmenu/gui_string_util.c b/grub-core/gfxmenu/gui_string_util.c
-index a9a415e31..ba1e1eab3 100644
+index a9a415e..ba1e1ea 100644
 --- a/grub-core/gfxmenu/gui_string_util.c
 +++ b/grub-core/gfxmenu/gui_string_util.c
 @@ -55,7 +55,7 @@ canonicalize_path (const char *path)
@@ -682,7 +681,7 @@ index a9a415e31..ba1e1eab3 100644
      return 0;
  
 diff --git a/grub-core/gfxmenu/widget-box.c b/grub-core/gfxmenu/widget-box.c
-index b60602889..470597ded 100644
+index b606028..470597d 100644
 --- a/grub-core/gfxmenu/widget-box.c
 +++ b/grub-core/gfxmenu/widget-box.c
 @@ -303,10 +303,10 @@ grub_gfxmenu_create_box (const char *pixmaps_prefix,
@@ -699,7 +698,7 @@ index b60602889..470597ded 100644
    /* Initialize all pixmap pointers to NULL so that proper destruction can
       be performed if an error is encountered partway through construction.  */
 diff --git a/grub-core/io/gzio.c b/grub-core/io/gzio.c
-index 6208a9763..43d98a7bd 100644
+index 6208a97..43d98a7 100644
 --- a/grub-core/io/gzio.c
 +++ b/grub-core/io/gzio.c
 @@ -554,7 +554,7 @@ huft_build (unsigned *b,	/* code lengths in bits (all assumed <= BMAX) */
@@ -712,7 +711,7 @@ index 6208a9763..43d98a7bd 100644
  		{
  		  if (h)
 diff --git a/grub-core/kern/efi/efi.c b/grub-core/kern/efi/efi.c
-index 6e1ceb905..dc31caa21 100644
+index 6e1ceb9..dc31caa 100644
 --- a/grub-core/kern/efi/efi.c
 +++ b/grub-core/kern/efi/efi.c
 @@ -202,7 +202,7 @@ grub_efi_set_variable(const char *var, const grub_efi_guid_t *guid,
@@ -743,7 +742,7 @@ index 6e1ceb905..dc31caa21 100644
  	    {
  	      grub_free (name);
 diff --git a/grub-core/kern/emu/hostdisk.c b/grub-core/kern/emu/hostdisk.c
-index 8ac523953..f90b6c9ce 100644
+index 8ac5239..f90b6c9 100644
 --- a/grub-core/kern/emu/hostdisk.c
 +++ b/grub-core/kern/emu/hostdisk.c
 @@ -627,7 +627,7 @@ static char *
@@ -756,7 +755,7 @@ index 8ac523953..f90b6c9ce 100644
    size_t i;
    int first = 1;
 diff --git a/grub-core/kern/fs.c b/grub-core/kern/fs.c
-index 2b85f4950..f90be6566 100644
+index 2b85f49..f90be65 100644
 --- a/grub-core/kern/fs.c
 +++ b/grub-core/kern/fs.c
 @@ -151,7 +151,7 @@ grub_fs_blocklist_open (grub_file_t file, const char *name)
@@ -769,7 +768,7 @@ index 2b85f4950..f90be6566 100644
      return 0;
  
 diff --git a/grub-core/kern/misc.c b/grub-core/kern/misc.c
-index 18cad5803..83c068d61 100644
+index 18cad58..83c068d 100644
 --- a/grub-core/kern/misc.c
 +++ b/grub-core/kern/misc.c
 @@ -691,7 +691,7 @@ parse_printf_args (const char *fmt0, struct printf_args *args,
@@ -782,7 +781,7 @@ index 18cad5803..83c068d61 100644
  	{
  	  grub_errno = GRUB_ERR_NONE;
 diff --git a/grub-core/kern/parser.c b/grub-core/kern/parser.c
-index 78175aac2..619db3122 100644
+index 78175aa..619db31 100644
 --- a/grub-core/kern/parser.c
 +++ b/grub-core/kern/parser.c
 @@ -213,7 +213,7 @@ grub_parser_split_cmdline (const char *cmdline,
@@ -795,7 +794,7 @@ index 78175aac2..619db3122 100644
      {
        grub_free (args);
 diff --git a/grub-core/kern/uboot/uboot.c b/grub-core/kern/uboot/uboot.c
-index be4816fe6..aac8f9ae1 100644
+index be4816f..aac8f9a 100644
 --- a/grub-core/kern/uboot/uboot.c
 +++ b/grub-core/kern/uboot/uboot.c
 @@ -133,7 +133,7 @@ grub_uboot_dev_enum (void)
@@ -808,7 +807,7 @@ index be4816fe6..aac8f9ae1 100644
      return 0;
  
 diff --git a/grub-core/lib/libgcrypt/cipher/ac.c b/grub-core/lib/libgcrypt/cipher/ac.c
-index f5e946a2d..63f6fcd11 100644
+index f5e946a..63f6fcd 100644
 --- a/grub-core/lib/libgcrypt/cipher/ac.c
 +++ b/grub-core/lib/libgcrypt/cipher/ac.c
 @@ -185,7 +185,7 @@ ac_data_mpi_copy (gcry_ac_mpi_t *data_mpis, unsigned int data_mpis_n,
@@ -848,7 +847,7 @@ index f5e946a2d..63f6fcd11 100644
      {
        err = gcry_error_from_errno (errno);
 diff --git a/grub-core/lib/libgcrypt/cipher/primegen.c b/grub-core/lib/libgcrypt/cipher/primegen.c
-index 2788e349f..b12e79b19 100644
+index 2788e34..b12e79b 100644
 --- a/grub-core/lib/libgcrypt/cipher/primegen.c
 +++ b/grub-core/lib/libgcrypt/cipher/primegen.c
 @@ -383,7 +383,7 @@ prime_generate_internal (int need_q_factor,
@@ -870,7 +869,7 @@ index 2788e349f..b12e79b19 100644
    val_2  = mpi_alloc_set_ui( 2 );
    val_3 = mpi_alloc_set_ui( 3);
 diff --git a/grub-core/lib/libgcrypt/cipher/pubkey.c b/grub-core/lib/libgcrypt/cipher/pubkey.c
-index 910982141..ca087ad75 100644
+index 9109821..ca087ad 100644
 --- a/grub-core/lib/libgcrypt/cipher/pubkey.c
 +++ b/grub-core/lib/libgcrypt/cipher/pubkey.c
 @@ -2941,7 +2941,7 @@ gcry_pk_encrypt (gcry_sexp_t *r_ciph, gcry_sexp_t s_data, gcry_sexp_t s_pkey)
@@ -892,7 +891,7 @@ index 910982141..ca087ad75 100644
          {
            rc = gpg_err_code_from_syserror ();
 diff --git a/grub-core/lib/priority_queue.c b/grub-core/lib/priority_queue.c
-index 659be0b7f..7d5e7c05a 100644
+index 659be0b..7d5e7c0 100644
 --- a/grub-core/lib/priority_queue.c
 +++ b/grub-core/lib/priority_queue.c
 @@ -92,7 +92,7 @@ grub_priority_queue_new (grub_size_t elsize,
@@ -905,7 +904,7 @@ index 659be0b7f..7d5e7c05a 100644
      return 0;
    ret = (struct grub_priority_queue *) grub_malloc (sizeof (*ret));
 diff --git a/grub-core/lib/reed_solomon.c b/grub-core/lib/reed_solomon.c
-index ee9fa7b4f..467305b46 100644
+index ee9fa7b..467305b 100644
 --- a/grub-core/lib/reed_solomon.c
 +++ b/grub-core/lib/reed_solomon.c
 @@ -20,6 +20,7 @@
@@ -931,7 +930,7 @@ index ee9fa7b4f..467305b46 100644
    /* Multiply with X - a^r */
    for (j = 0; j < rs; j++)
 diff --git a/grub-core/lib/relocator.c b/grub-core/lib/relocator.c
-index ea3ebc719..5847aac36 100644
+index ea3ebc7..5847aac 100644
 --- a/grub-core/lib/relocator.c
 +++ b/grub-core/lib/relocator.c
 @@ -495,9 +495,9 @@ malloc_in_range (struct grub_relocator *rel,
@@ -967,7 +966,7 @@ index ea3ebc719..5847aac36 100644
        {
  	grub_free (from);
 diff --git a/grub-core/lib/zstd/fse_decompress.c b/grub-core/lib/zstd/fse_decompress.c
-index 72bbead5b..2227b84bc 100644
+index 72bbead..2227b84 100644
 --- a/grub-core/lib/zstd/fse_decompress.c
 +++ b/grub-core/lib/zstd/fse_decompress.c
 @@ -82,7 +82,7 @@
@@ -980,7 +979,7 @@ index 72bbead5b..2227b84bc 100644
  
  void FSE_freeDTable (FSE_DTable* dt)
 diff --git a/grub-core/loader/arm/linux.c b/grub-core/loader/arm/linux.c
-index 092e8e307..979d425df 100644
+index 092e8e3..979d425 100644
 --- a/grub-core/loader/arm/linux.c
 +++ b/grub-core/loader/arm/linux.c
 @@ -82,7 +82,7 @@ linux_prepare_atag (void *target_atag)
@@ -993,7 +992,7 @@ index 092e8e307..979d425df 100644
      return grub_errno;
  
 diff --git a/grub-core/loader/efi/chainloader.c b/grub-core/loader/efi/chainloader.c
-index 04e815c05..b9a2df34b 100644
+index 04e815c..b9a2df3 100644
 --- a/grub-core/loader/efi/chainloader.c
 +++ b/grub-core/loader/efi/chainloader.c
 @@ -126,7 +126,7 @@ copy_file_path (grub_efi_file_path_device_path_t *fp,
@@ -1006,7 +1005,7 @@ index 04e815c05..b9a2df34b 100644
      return;
  
 diff --git a/grub-core/loader/i386/bsdXX.c b/grub-core/loader/i386/bsdXX.c
-index af6741d15..a8d8bf7da 100644
+index af6741d..a8d8bf7 100644
 --- a/grub-core/loader/i386/bsdXX.c
 +++ b/grub-core/loader/i386/bsdXX.c
 @@ -48,7 +48,7 @@ read_headers (grub_file_t file, const char *filename, Elf_Ehdr *e, char **shdr)
@@ -1019,7 +1018,7 @@ index af6741d15..a8d8bf7da 100644
      return grub_errno;
  
 diff --git a/grub-core/loader/i386/xnu.c b/grub-core/loader/i386/xnu.c
-index e64ed08f5..b7d176b5d 100644
+index e64ed08..b7d176b 100644
 --- a/grub-core/loader/i386/xnu.c
 +++ b/grub-core/loader/i386/xnu.c
 @@ -295,7 +295,7 @@ grub_xnu_devprop_add_property_utf8 (struct grub_xnu_devprop_device_descriptor *d
@@ -1041,7 +1040,7 @@ index e64ed08f5..b7d176b5d 100644
      return grub_errno;
    grub_memcpy (utf16, name, sizeof (grub_uint16_t) * namelen);
 diff --git a/grub-core/loader/macho.c b/grub-core/loader/macho.c
-index 085f9c689..05710c48e 100644
+index 085f9c6..05710c4 100644
 --- a/grub-core/loader/macho.c
 +++ b/grub-core/loader/macho.c
 @@ -97,7 +97,7 @@ grub_macho_file (grub_file_t file, const char *filename, int is_64bit)
@@ -1054,7 +1053,7 @@ index 085f9c689..05710c48e 100644
  	goto fail;
        if (grub_file_read (macho->file, archs,
 diff --git a/grub-core/loader/multiboot_elfxx.c b/grub-core/loader/multiboot_elfxx.c
-index 70cd1db51..cc6853692 100644
+index 70cd1db..cc68536 100644
 --- a/grub-core/loader/multiboot_elfxx.c
 +++ b/grub-core/loader/multiboot_elfxx.c
 @@ -217,7 +217,7 @@ CONCAT(grub_multiboot_load_elf, XX) (mbi_load_data_t *mld)
@@ -1067,7 +1066,7 @@ index 70cd1db51..cc6853692 100644
  	return grub_errno;
        
 diff --git a/grub-core/loader/xnu.c b/grub-core/loader/xnu.c
-index e0f47e72b..2f0ebd0b8 100644
+index e0f47e7..2f0ebd0 100644
 --- a/grub-core/loader/xnu.c
 +++ b/grub-core/loader/xnu.c
 @@ -801,7 +801,7 @@ grub_cmd_xnu_mkext (grub_command_t cmd __attribute__ ((unused)),
@@ -1080,7 +1079,7 @@ index e0f47e72b..2f0ebd0b8 100644
  	{
  	  grub_file_close (file);
 diff --git a/grub-core/mmap/mmap.c b/grub-core/mmap/mmap.c
-index 6a31cbae3..57b4e9a72 100644
+index 6a31cba..57b4e9a 100644
 --- a/grub-core/mmap/mmap.c
 +++ b/grub-core/mmap/mmap.c
 @@ -143,9 +143,9 @@ grub_mmap_iterate (grub_memory_hook_t hook, void *hook_data)
@@ -1096,7 +1095,7 @@ index 6a31cbae3..57b4e9a72 100644
    if (! ctx.scanline_events || !present)
      {
 diff --git a/grub-core/net/bootp.c b/grub-core/net/bootp.c
-index 558d97ba1..dd0ffcdae 100644
+index 558d97b..dd0ffcd 100644
 --- a/grub-core/net/bootp.c
 +++ b/grub-core/net/bootp.c
 @@ -1559,7 +1559,7 @@ grub_cmd_bootp (struct grub_command *cmd __attribute__ ((unused)),
@@ -1109,7 +1108,7 @@ index 558d97ba1..dd0ffcdae 100644
      return grub_errno;
  
 diff --git a/grub-core/net/dns.c b/grub-core/net/dns.c
-index 5d9afe093..e332d5eb4 100644
+index 5d9afe0..e332d5e 100644
 --- a/grub-core/net/dns.c
 +++ b/grub-core/net/dns.c
 @@ -285,8 +285,8 @@ recv_hook (grub_net_udp_socket_t sock __attribute__ ((unused)),
@@ -1144,7 +1143,7 @@ index 5d9afe093..e332d5eb4 100644
      return grub_errno;
  
 diff --git a/grub-core/net/net.c b/grub-core/net/net.c
-index b917a75d5..fed7bc57c 100644
+index b917a75..fed7bc5 100644
 --- a/grub-core/net/net.c
 +++ b/grub-core/net/net.c
 @@ -333,8 +333,8 @@ grub_cmd_ipv6_autoconf (struct grub_command *cmd __attribute__ ((unused)),
@@ -1159,7 +1158,7 @@ index b917a75d5..fed7bc57c 100644
      {
        grub_free (ifaces);
 diff --git a/grub-core/normal/charset.c b/grub-core/normal/charset.c
-index b0ab47d73..d57fb72fa 100644
+index b0ab47d..d57fb72 100644
 --- a/grub-core/normal/charset.c
 +++ b/grub-core/normal/charset.c
 @@ -203,7 +203,7 @@ grub_utf8_to_ucs4_alloc (const char *msg, grub_uint32_t **unicode_msg,
@@ -1201,7 +1200,7 @@ index b0ab47d73..d57fb72fa 100644
      return -1;
    for (ptr = logical; ptr <= logical + logical_len; ptr++)
 diff --git a/grub-core/normal/cmdline.c b/grub-core/normal/cmdline.c
-index c037d5050..c57242e2e 100644
+index c037d50..c57242e 100644
 --- a/grub-core/normal/cmdline.c
 +++ b/grub-core/normal/cmdline.c
 @@ -41,7 +41,7 @@ grub_err_t
@@ -1268,7 +1267,7 @@ index c037d5050..c57242e2e 100644
  		{
  		  grub_print_error ();
 diff --git a/grub-core/normal/menu_entry.c b/grub-core/normal/menu_entry.c
-index cdf3590a3..1993995be 100644
+index cdf3590..1993995 100644
 --- a/grub-core/normal/menu_entry.c
 +++ b/grub-core/normal/menu_entry.c
 @@ -95,8 +95,8 @@ init_line (struct screen *screen, struct line *linep)
@@ -1328,7 +1327,7 @@ index cdf3590a3..1993995be 100644
      {
        grub_print_error ();
 diff --git a/grub-core/normal/menu_text.c b/grub-core/normal/menu_text.c
-index e22bb91f6..18240e76c 100644
+index e22bb91..18240e7 100644
 --- a/grub-core/normal/menu_text.c
 +++ b/grub-core/normal/menu_text.c
 @@ -78,7 +78,7 @@ grub_print_message_indented_real (const char *msg, int margin_left,
@@ -1350,7 +1349,7 @@ index e22bb91f6..18240e76c 100644
      /* XXX How to show this error?  */
      return;
 diff --git a/grub-core/normal/term.c b/grub-core/normal/term.c
-index a1e5c5a0d..cc8c173b6 100644
+index a1e5c5a..cc8c173 100644
 --- a/grub-core/normal/term.c
 +++ b/grub-core/normal/term.c
 @@ -264,7 +264,7 @@ grub_term_save_pos (void)
@@ -1372,7 +1371,7 @@ index a1e5c5a0d..cc8c173b6 100644
    grub_error_pop ();
  
 diff --git a/grub-core/osdep/linux/getroot.c b/grub-core/osdep/linux/getroot.c
-index 7adc0f30e..a5bd0752f 100644
+index 7adc0f3..a5bd075 100644
 --- a/grub-core/osdep/linux/getroot.c
 +++ b/grub-core/osdep/linux/getroot.c
 @@ -168,7 +168,7 @@ grub_util_raid_getmembers (const char *name, int bootable)
@@ -1403,7 +1402,7 @@ index 7adc0f30e..a5bd0752f 100644
  again:
    fp = grub_util_fopen ("/proc/self/mountinfo", "r");
 diff --git a/grub-core/osdep/unix/config.c b/grub-core/osdep/unix/config.c
-index 5478030fd..89dc70d93 100644
+index 5478030..89dc70d 100644
 --- a/grub-core/osdep/unix/config.c
 +++ b/grub-core/osdep/unix/config.c
 @@ -130,7 +130,7 @@ grub_util_load_config (struct grub_util_config *cfg)
@@ -1416,7 +1415,7 @@ index 5478030fd..89dc70d93 100644
    if (grub_util_is_regular (cfgfile))
      sorted_cfgpaths[i++] = xstrdup (cfgfile);
 diff --git a/grub-core/osdep/windows/getroot.c b/grub-core/osdep/windows/getroot.c
-index 661d95461..eada663b2 100644
+index 661d954..eada663 100644
 --- a/grub-core/osdep/windows/getroot.c
 +++ b/grub-core/osdep/windows/getroot.c
 @@ -59,7 +59,7 @@ grub_get_mount_point (const TCHAR *path)
@@ -1429,7 +1428,7 @@ index 661d95461..eada663b2 100644
    /* When pointing to EFI system partition GetVolumePathName fails
       for ESP root and returns abberant information for everything
 diff --git a/grub-core/osdep/windows/hostdisk.c b/grub-core/osdep/windows/hostdisk.c
-index 355100789..0be327394 100644
+index 3551007..0be3273 100644
 --- a/grub-core/osdep/windows/hostdisk.c
 +++ b/grub-core/osdep/windows/hostdisk.c
 @@ -111,7 +111,7 @@ grub_util_get_windows_path_real (const char *path)
@@ -1451,7 +1450,7 @@ index 355100789..0be327394 100644
    pattern[l] = '\\';
    pattern[l + 1] = '*';
 diff --git a/grub-core/osdep/windows/init.c b/grub-core/osdep/windows/init.c
-index e8ffd62c6..6297de632 100644
+index e8ffd62..6297de6 100644
 --- a/grub-core/osdep/windows/init.c
 +++ b/grub-core/osdep/windows/init.c
 @@ -161,7 +161,7 @@ grub_util_host_init (int *argc __attribute__ ((unused)),
@@ -1464,7 +1463,7 @@ index e8ffd62c6..6297de632 100644
    for (i = 0; i < *argc; i++)
      (*argv)[i] = grub_util_tchar_to_utf8 (targv[i]); 
 diff --git a/grub-core/osdep/windows/platform.c b/grub-core/osdep/windows/platform.c
-index a3f738fb9..b160949d8 100644
+index a3f738f..b160949 100644
 --- a/grub-core/osdep/windows/platform.c
 +++ b/grub-core/osdep/windows/platform.c
 @@ -231,8 +231,8 @@ grub_install_register_efi (grub_device_t efidir_grub_dev, const char *efidir,
@@ -1479,7 +1478,7 @@ index a3f738fb9..b160949d8 100644
  				      (const grub_uint8_t *) efi_distributor,
  				      distrib8_len, 0);
 diff --git a/grub-core/osdep/windows/relpath.c b/grub-core/osdep/windows/relpath.c
-index cb0861744..478e8ef14 100644
+index cb08617..478e8ef 100644
 --- a/grub-core/osdep/windows/relpath.c
 +++ b/grub-core/osdep/windows/relpath.c
 @@ -72,7 +72,7 @@ grub_make_system_path_relative_to_its_root (const char *path)
@@ -1492,7 +1491,7 @@ index cb0861744..478e8ef14 100644
        && dirwindows[offset] != '/'
        && dirwindows[offset])
 diff --git a/grub-core/partmap/gpt.c b/grub-core/partmap/gpt.c
-index 103f6796f..72a2e37cd 100644
+index 103f679..72a2e37 100644
 --- a/grub-core/partmap/gpt.c
 +++ b/grub-core/partmap/gpt.c
 @@ -199,7 +199,7 @@ gpt_partition_map_embed (struct grub_disk *disk, unsigned int *nsectors,
@@ -1505,7 +1504,7 @@ index 103f6796f..72a2e37cd 100644
      return grub_errno;
    for (i = 0; i < *nsectors; i++)
 diff --git a/grub-core/partmap/msdos.c b/grub-core/partmap/msdos.c
-index 7b8e45076..ee3f24982 100644
+index 7b8e450..ee3f249 100644
 --- a/grub-core/partmap/msdos.c
 +++ b/grub-core/partmap/msdos.c
 @@ -337,7 +337,7 @@ pc_partition_map_embed (struct grub_disk *disk, unsigned int *nsectors,
@@ -1518,7 +1517,7 @@ index 7b8e45076..ee3f24982 100644
  	return grub_errno;
        for (i = 0; i < *nsectors; i++)
 diff --git a/grub-core/script/execute.c b/grub-core/script/execute.c
-index ee299fd0e..c8d6806fe 100644
+index ee299fd..c8d6806 100644
 --- a/grub-core/script/execute.c
 +++ b/grub-core/script/execute.c
 @@ -553,7 +553,7 @@ gettext_append (struct grub_script_argv *result, const char *orig_str)
@@ -1531,7 +1530,7 @@ index ee299fd0e..c8d6806fe 100644
    if (parse_string (orig_str, gettext_save_allow, &ctx, 0))
      goto fail;
 diff --git a/grub-core/tests/fake_input.c b/grub-core/tests/fake_input.c
-index 2d6085298..b5eb516be 100644
+index 2d60852..b5eb516 100644
 --- a/grub-core/tests/fake_input.c
 +++ b/grub-core/tests/fake_input.c
 @@ -49,7 +49,7 @@ grub_terminal_input_fake_sequence (int *seq_in, int nseq_in)
@@ -1544,7 +1543,7 @@ index 2d6085298..b5eb516be 100644
      return;
  
 diff --git a/grub-core/tests/video_checksum.c b/grub-core/tests/video_checksum.c
-index 74d5b65e5..44d081069 100644
+index 74d5b65..44d0810 100644
 --- a/grub-core/tests/video_checksum.c
 +++ b/grub-core/tests/video_checksum.c
 @@ -336,7 +336,7 @@ grub_video_capture_write_bmp (const char *fname,
@@ -1575,7 +1574,7 @@ index 74d5b65e5..44d081069 100644
  	grub_uint16_t gmask = ((1 << mode_info->green_mask_size) - 1);
  	grub_uint16_t bmask = ((1 << mode_info->blue_mask_size) - 1);
 diff --git a/grub-core/video/capture.c b/grub-core/video/capture.c
-index 4f83c7441..4d3195e01 100644
+index 4f83c74..4d3195e 100644
 --- a/grub-core/video/capture.c
 +++ b/grub-core/video/capture.c
 @@ -89,7 +89,7 @@ grub_video_capture_start (const struct grub_video_mode_info *mode_info,
@@ -1588,7 +1587,7 @@ index 4f83c7441..4d3195e01 100644
      return grub_errno;
    
 diff --git a/grub-core/video/emu/sdl.c b/grub-core/video/emu/sdl.c
-index a2f639f66..0ebab6f57 100644
+index a2f639f..0ebab6f 100644
 --- a/grub-core/video/emu/sdl.c
 +++ b/grub-core/video/emu/sdl.c
 @@ -172,7 +172,7 @@ grub_video_sdl_set_palette (unsigned int start, unsigned int count,
@@ -1601,7 +1600,7 @@ index a2f639f66..0ebab6f57 100644
  	{
  	  tmp[i].r = palette_data[i].r;
 diff --git a/grub-core/video/i386/pc/vga.c b/grub-core/video/i386/pc/vga.c
-index 01f47112d..b2f776c99 100644
+index 01f4711..b2f776c 100644
 --- a/grub-core/video/i386/pc/vga.c
 +++ b/grub-core/video/i386/pc/vga.c
 @@ -127,7 +127,7 @@ grub_video_vga_setup (unsigned int width, unsigned int height,
@@ -1614,7 +1613,7 @@ index 01f47112d..b2f776c99 100644
    framebuffer.back_page = 0;
    if (!framebuffer.temporary_buffer)
 diff --git a/grub-core/video/readers/png.c b/grub-core/video/readers/png.c
-index 777e71334..61bd64537 100644
+index 777e713..61bd645 100644
 --- a/grub-core/video/readers/png.c
 +++ b/grub-core/video/readers/png.c
 @@ -309,7 +309,7 @@ grub_png_decode_image_header (struct grub_png_data *data)
@@ -1627,7 +1626,7 @@ index 777e71334..61bd64537 100644
          return grub_errno;
  
 diff --git a/include/grub/unicode.h b/include/grub/unicode.h
-index a0403e91f..4de986a85 100644
+index a0403e9..4de986a 100644
 --- a/include/grub/unicode.h
 +++ b/include/grub/unicode.h
 @@ -293,7 +293,7 @@ grub_unicode_glyph_dup (const struct grub_unicode_glyph *in)
@@ -1649,7 +1648,7 @@ index a0403e91f..4de986a85 100644
  	return;
        grub_memcpy (out->combining_ptr, in->combining_ptr,
 diff --git a/util/getroot.c b/util/getroot.c
-index cdd41153c..6ae35ecaa 100644
+index cdd4115..6ae35ec 100644
 --- a/util/getroot.c
 +++ b/util/getroot.c
 @@ -200,7 +200,7 @@ make_device_name (const char *drive)
@@ -1662,7 +1661,7 @@ index cdd41153c..6ae35ecaa 100644
    for (iptr = drive; *iptr; iptr++)
      {
 diff --git a/util/grub-file.c b/util/grub-file.c
-index 50c18b683..b2e7dd69f 100644
+index 50c18b6..b2e7dd6 100644
 --- a/util/grub-file.c
 +++ b/util/grub-file.c
 @@ -54,7 +54,7 @@ main (int argc, char *argv[])
@@ -1675,7 +1674,7 @@ index 50c18b683..b2e7dd69f 100644
    if (argc == 2 && strcmp (argv[1], "--version") == 0)
      {
 diff --git a/util/grub-fstest.c b/util/grub-fstest.c
-index f14e02d97..57246af7c 100644
+index f14e02d..57246af 100644
 --- a/util/grub-fstest.c
 +++ b/util/grub-fstest.c
 @@ -650,7 +650,7 @@ argp_parser (int key, char *arg, struct argp_state *state)
@@ -1697,7 +1696,7 @@ index f14e02d97..57246af7c 100644
    argp_parse (&argp, argc, argv, 0, 0, 0);
  
 diff --git a/util/grub-install-common.c b/util/grub-install-common.c
-index fdfe2c7ea..447504d3f 100644
+index fdfe2c7..447504d 100644
 --- a/util/grub-install-common.c
 +++ b/util/grub-install-common.c
 @@ -286,7 +286,7 @@ handle_install_list (struct install_list *il, const char *val,
@@ -1710,7 +1709,7 @@ index fdfe2c7ea..447504d3f 100644
    for (ce = il->entries; ; ce++)
      {
 diff --git a/util/grub-install.c b/util/grub-install.c
-index f408b1986..843dfc7c8 100644
+index f408b19..843dfc7 100644
 --- a/util/grub-install.c
 +++ b/util/grub-install.c
 @@ -658,7 +658,7 @@ device_map_check_duplicates (const char *dev_map)
@@ -1732,7 +1731,7 @@ index f408b1986..843dfc7c8 100644
    for (curdev = grub_devices, curdrive = grub_drives; *curdev; curdev++,
         curdrive++)
 diff --git a/util/grub-mkimagexx.c b/util/grub-mkimagexx.c
-index bc087c2b5..d97d0e7be 100644
+index bc087c2..d97d0e7 100644
 --- a/util/grub-mkimagexx.c
 +++ b/util/grub-mkimagexx.c
 @@ -2294,10 +2294,8 @@ SUFFIX (grub_mkimage_load_image) (const char *kernel_path,
@@ -1749,7 +1748,7 @@ index bc087c2b5..d97d0e7be 100644
    SUFFIX (locate_sections) (e, kernel_path, &smd, layout, image_target);
  
 diff --git a/util/grub-mkrescue.c b/util/grub-mkrescue.c
-index 45d6140d3..cb972f120 100644
+index 45d6140..cb972f1 100644
 --- a/util/grub-mkrescue.c
 +++ b/util/grub-mkrescue.c
 @@ -441,8 +441,8 @@ main (int argc, char *argv[])
@@ -1764,7 +1763,7 @@ index 45d6140d3..cb972f120 100644
    xorriso_tail_argc = 0;
    /* Program name */
 diff --git a/util/grub-mkstandalone.c b/util/grub-mkstandalone.c
-index 4907d44c0..edf309717 100644
+index 4907d44..edf3097 100644
 --- a/util/grub-mkstandalone.c
 +++ b/util/grub-mkstandalone.c
 @@ -296,7 +296,7 @@ main (int argc, char *argv[])
@@ -1777,7 +1776,7 @@ index 4907d44c0..edf309717 100644
    argp_parse (&argp, argc, argv, 0, 0, 0);
  
 diff --git a/util/grub-pe2elf.c b/util/grub-pe2elf.c
-index 0d4084a10..11331294f 100644
+index 0d4084a..1133129 100644
 --- a/util/grub-pe2elf.c
 +++ b/util/grub-pe2elf.c
 @@ -100,9 +100,9 @@ write_section_data (FILE* fp, const char *name, char *image,
@@ -1817,7 +1816,7 @@ index 0d4084a10..11331294f 100644
    for (i = 0; i < (int) pe_chdr->num_symbols;
         i += pe_symtab->num_aux + 1, pe_symtab += pe_symtab->num_aux + 1)
 diff --git a/util/grub-probe.c b/util/grub-probe.c
-index 81d27eead..cbe6ed94c 100644
+index 81d27ee..cbe6ed9 100644
 --- a/util/grub-probe.c
 +++ b/util/grub-probe.c
 @@ -361,8 +361,8 @@ probe (const char *path, char **device_names, char delim)

--- a/debian/patches/0085-malloc-Use-overflow-checking-primitives-where-we-do-.patch
+++ b/debian/patches/0085-malloc-Use-overflow-checking-primitives-where-we-do-.patch
@@ -1,4 +1,3 @@
-From ae3e37e95e16efdf10df001ef94b1404ea258a46 Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Mon, 15 Jun 2020 12:28:27 -0400
 Subject: malloc: Use overflow checking primitives where we do complex
@@ -29,33 +28,33 @@ Fixes: CVE-2020-14309, CVE-2020-14310, CVE-2020-14311
 Signed-off-by: Peter Jones <pjones@redhat.com>
 Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
 ---
- grub-core/commands/legacycfg.c | 29 +++++++++++++++----
- grub-core/commands/wildcard.c  | 36 ++++++++++++++++++++----
- grub-core/disk/ldm.c           | 32 +++++++++++++++------
- grub-core/font/font.c          |  7 ++++-
- grub-core/fs/btrfs.c           | 28 +++++++++++++------
- grub-core/fs/ext2.c            | 10 ++++++-
- grub-core/fs/iso9660.c         | 51 ++++++++++++++++++++++++----------
- grub-core/fs/sfs.c             | 27 ++++++++++++++----
- grub-core/fs/squash4.c         | 45 ++++++++++++++++++++++--------
- grub-core/fs/udf.c             | 41 +++++++++++++++++----------
- grub-core/fs/xfs.c             | 11 +++++---
- grub-core/fs/zfs/zfs.c         | 22 ++++++++++-----
- grub-core/fs/zfs/zfscrypt.c    |  7 ++++-
- grub-core/lib/arg.c            | 20 +++++++++++--
- grub-core/loader/i386/bsd.c    |  8 +++++-
- grub-core/net/dns.c            |  9 +++++-
- grub-core/normal/charset.c     | 10 +++++--
- grub-core/normal/cmdline.c     | 14 ++++++++--
- grub-core/normal/menu_entry.c  | 13 +++++++--
- grub-core/script/argv.c        | 16 +++++++++--
- grub-core/script/lexer.c       | 21 ++++++++++++--
- grub-core/video/bitmap.c       | 25 +++++++++++------
- grub-core/video/readers/png.c  | 13 +++++++--
+ grub-core/commands/legacycfg.c | 29 +++++++++++++++++++-----
+ grub-core/commands/wildcard.c  | 36 ++++++++++++++++++++++++-----
+ grub-core/disk/ldm.c           | 32 ++++++++++++++++++--------
+ grub-core/font/font.c          |  7 +++++-
+ grub-core/fs/btrfs.c           | 28 +++++++++++++++--------
+ grub-core/fs/ext2.c            | 10 ++++++++-
+ grub-core/fs/iso9660.c         | 51 +++++++++++++++++++++++++++++-------------
+ grub-core/fs/sfs.c             | 27 +++++++++++++++++-----
+ grub-core/fs/squash4.c         | 45 ++++++++++++++++++++++++++++---------
+ grub-core/fs/udf.c             | 41 +++++++++++++++++++++------------
+ grub-core/fs/xfs.c             | 11 +++++----
+ grub-core/fs/zfs/zfs.c         | 22 ++++++++++++------
+ grub-core/fs/zfs/zfscrypt.c    |  7 +++++-
+ grub-core/lib/arg.c            | 20 +++++++++++++++--
+ grub-core/loader/i386/bsd.c    |  8 ++++++-
+ grub-core/net/dns.c            |  9 +++++++-
+ grub-core/normal/charset.c     | 10 +++++++--
+ grub-core/normal/cmdline.c     | 14 ++++++++++--
+ grub-core/normal/menu_entry.c  | 13 +++++++++--
+ grub-core/script/argv.c        | 16 +++++++++++--
+ grub-core/script/lexer.c       | 21 ++++++++++++++---
+ grub-core/video/bitmap.c       | 25 +++++++++++++--------
+ grub-core/video/readers/png.c  | 13 +++++++++--
  23 files changed, 382 insertions(+), 113 deletions(-)
 
 diff --git a/grub-core/commands/legacycfg.c b/grub-core/commands/legacycfg.c
-index 5e3ec0d5e..cc5971f4d 100644
+index 5e3ec0d..cc5971f 100644
 --- a/grub-core/commands/legacycfg.c
 +++ b/grub-core/commands/legacycfg.c
 @@ -32,6 +32,7 @@
@@ -118,7 +117,7 @@ index 5e3ec0d5e..cc5971f4d 100644
  		  grub_free (suffix);
  		  return grub_errno;
 diff --git a/grub-core/commands/wildcard.c b/grub-core/commands/wildcard.c
-index 4a106ca04..cc3290311 100644
+index 4a106ca..cc32903 100644
 --- a/grub-core/commands/wildcard.c
 +++ b/grub-core/commands/wildcard.c
 @@ -23,6 +23,7 @@
@@ -220,7 +219,7 @@ index 4a106ca04..cc3290311 100644
        return 1;
      }
 diff --git a/grub-core/disk/ldm.c b/grub-core/disk/ldm.c
-index e6323701a..58f8a53e1 100644
+index e632370..58f8a53 100644
 --- a/grub-core/disk/ldm.c
 +++ b/grub-core/disk/ldm.c
 @@ -25,6 +25,7 @@
@@ -291,7 +290,7 @@ index e6323701a..58f8a53e1 100644
  		    goto fail2;
  		  comp->segments = t;
 diff --git a/grub-core/font/font.c b/grub-core/font/font.c
-index 8e118b315..5edb477ac 100644
+index 8e118b3..5edb477 100644
 --- a/grub-core/font/font.c
 +++ b/grub-core/font/font.c
 @@ -30,6 +30,7 @@
@@ -318,7 +317,7 @@ index 8e118b315..5edb477ac 100644
      return 0;
  
 diff --git a/grub-core/fs/btrfs.c b/grub-core/fs/btrfs.c
-index 11272efc1..2b65bd56a 100644
+index 11272ef..2b65bd5 100644
 --- a/grub-core/fs/btrfs.c
 +++ b/grub-core/fs/btrfs.c
 @@ -40,6 +40,7 @@
@@ -375,7 +374,7 @@ index 11272efc1..2b65bd56a 100644
  	}
      }
 diff --git a/grub-core/fs/ext2.c b/grub-core/fs/ext2.c
-index 9b389802a..ac33bcd68 100644
+index 9b38980..ac33bcd 100644
 --- a/grub-core/fs/ext2.c
 +++ b/grub-core/fs/ext2.c
 @@ -46,6 +46,7 @@
@@ -410,7 +409,7 @@ index 9b389802a..ac33bcd68 100644
      return 0;
  
 diff --git a/grub-core/fs/iso9660.c b/grub-core/fs/iso9660.c
-index 4f1b52a55..7ba5b300b 100644
+index 4f1b52a..7ba5b30 100644
 --- a/grub-core/fs/iso9660.c
 +++ b/grub-core/fs/iso9660.c
 @@ -28,6 +28,7 @@
@@ -514,7 +513,7 @@ index 4f1b52a55..7ba5b300b 100644
  		      grub_free (ctx.filename);
  		    grub_free (node);
 diff --git a/grub-core/fs/sfs.c b/grub-core/fs/sfs.c
-index 90f7fb379..de2b107a4 100644
+index 90f7fb3..de2b107 100644
 --- a/grub-core/fs/sfs.c
 +++ b/grub-core/fs/sfs.c
 @@ -26,6 +26,7 @@
@@ -578,7 +577,7 @@ index 90f7fb379..de2b107a4 100644
  	*grub_latin1_to_utf8 ((grub_uint8_t *) *label,
  			      (const grub_uint8_t *) data->label,
 diff --git a/grub-core/fs/squash4.c b/grub-core/fs/squash4.c
-index 95d5c1e1f..785123894 100644
+index 95d5c1e..7851238 100644
 --- a/grub-core/fs/squash4.c
 +++ b/grub-core/fs/squash4.c
 @@ -26,6 +26,7 @@
@@ -677,7 +676,7 @@ index 95d5c1e1f..785123894 100644
  	  node->ino = ino;
  	  node->stack[node->stsize].ino_chunk = grub_le_to_cpu32 (dh.ino_chunk);
 diff --git a/grub-core/fs/udf.c b/grub-core/fs/udf.c
-index a83761674..21ac7f446 100644
+index a837616..21ac7f4 100644
 --- a/grub-core/fs/udf.c
 +++ b/grub-core/fs/udf.c
 @@ -28,6 +28,7 @@
@@ -786,7 +785,7 @@ index a83761674..21ac7f446 100644
    grub_free (out);
    grub_error (GRUB_ERR_BAD_FS, "invalid symlink");
 diff --git a/grub-core/fs/xfs.c b/grub-core/fs/xfs.c
-index 96ffecbfc..ea6590290 100644
+index 96ffecb..ea65902 100644
 --- a/grub-core/fs/xfs.c
 +++ b/grub-core/fs/xfs.c
 @@ -25,6 +25,7 @@
@@ -822,7 +821,7 @@ index 96ffecbfc..ea6590290 100644
    if (! data)
      goto fail;
 diff --git a/grub-core/fs/zfs/zfs.c b/grub-core/fs/zfs/zfs.c
-index 381dde556..36d0373a6 100644
+index 381dde5..36d0373 100644
 --- a/grub-core/fs/zfs/zfs.c
 +++ b/grub-core/fs/zfs/zfs.c
 @@ -55,6 +55,7 @@
@@ -875,7 +874,7 @@ index 381dde556..36d0373a6 100644
      return 0;
    grub_memcpy (ret, nvlist, sizeof (grub_uint32_t));
 diff --git a/grub-core/fs/zfs/zfscrypt.c b/grub-core/fs/zfs/zfscrypt.c
-index 1402e0bc2..de3b015f5 100644
+index 1402e0b..de3b015 100644
 --- a/grub-core/fs/zfs/zfscrypt.c
 +++ b/grub-core/fs/zfs/zfscrypt.c
 @@ -22,6 +22,7 @@
@@ -902,7 +901,7 @@ index 1402e0bc2..de3b015f5 100644
      return grub_errno;
    key->is_passphrase = passphrase;
 diff --git a/grub-core/lib/arg.c b/grub-core/lib/arg.c
-index fd7744a6f..3288609a5 100644
+index fd7744a..3288609 100644
 --- a/grub-core/lib/arg.c
 +++ b/grub-core/lib/arg.c
 @@ -23,6 +23,7 @@
@@ -954,7 +953,7 @@ index fd7744a6f..3288609a5 100644
      return 0;
  
 diff --git a/grub-core/loader/i386/bsd.c b/grub-core/loader/i386/bsd.c
-index 5b9b92d6b..ef0d63afc 100644
+index 5b9b92d..ef0d63a 100644
 --- a/grub-core/loader/i386/bsd.c
 +++ b/grub-core/loader/i386/bsd.c
 @@ -35,6 +35,7 @@
@@ -984,7 +983,7 @@ index 5b9b92d6b..ef0d63afc 100644
      return grub_errno;
  
 diff --git a/grub-core/net/dns.c b/grub-core/net/dns.c
-index e332d5eb4..906ec7d67 100644
+index e332d5e..906ec7d 100644
 --- a/grub-core/net/dns.c
 +++ b/grub-core/net/dns.c
 @@ -22,6 +22,7 @@
@@ -1013,7 +1012,7 @@ index e332d5eb4..906ec7d67 100644
  	return grub_errno;
        dns_servers_alloc = na;
 diff --git a/grub-core/normal/charset.c b/grub-core/normal/charset.c
-index d57fb72fa..4dfcc3107 100644
+index d57fb72..4dfcc31 100644
 --- a/grub-core/normal/charset.c
 +++ b/grub-core/normal/charset.c
 @@ -48,6 +48,7 @@
@@ -1050,7 +1049,7 @@ index d57fb72fa..4dfcc3107 100644
  		  continue;
  		}
 diff --git a/grub-core/normal/cmdline.c b/grub-core/normal/cmdline.c
-index c57242e2e..de03fe63b 100644
+index c57242e..de03fe6 100644
 --- a/grub-core/normal/cmdline.c
 +++ b/grub-core/normal/cmdline.c
 @@ -28,6 +28,7 @@
@@ -1086,7 +1085,7 @@ index c57242e2e..de03fe63b 100644
  	  grub_errno = GRUB_ERR_NONE;
  	  (*max_len) /= 2;
 diff --git a/grub-core/normal/menu_entry.c b/grub-core/normal/menu_entry.c
-index 1993995be..50eef918c 100644
+index 1993995..50eef91 100644
 --- a/grub-core/normal/menu_entry.c
 +++ b/grub-core/normal/menu_entry.c
 @@ -27,6 +27,7 @@
@@ -1119,7 +1118,7 @@ index 1993995be..50eef918c 100644
  
    return 1;
 diff --git a/grub-core/script/argv.c b/grub-core/script/argv.c
-index 217ec5d1e..5751fdd57 100644
+index 217ec5d..5751fdd 100644
 --- a/grub-core/script/argv.c
 +++ b/grub-core/script/argv.c
 @@ -20,6 +20,7 @@
@@ -1170,7 +1169,7 @@ index 217ec5d1e..5751fdd57 100644
      return 1;
  
 diff --git a/grub-core/script/lexer.c b/grub-core/script/lexer.c
-index c6bd3172f..5fb0cbd0b 100644
+index c6bd317..5fb0cbd 100644
 --- a/grub-core/script/lexer.c
 +++ b/grub-core/script/lexer.c
 @@ -24,6 +24,7 @@
@@ -1231,7 +1230,7 @@ index c6bd3172f..5fb0cbd0b 100644
      }
  
 diff --git a/grub-core/video/bitmap.c b/grub-core/video/bitmap.c
-index b2e031566..6256e209a 100644
+index b2e0315..6256e20 100644
 --- a/grub-core/video/bitmap.c
 +++ b/grub-core/video/bitmap.c
 @@ -23,6 +23,7 @@
@@ -1286,7 +1285,7 @@ index b2e031566..6256e209a 100644
  
  /* Frees all resources allocated by bitmap.  */
 diff --git a/grub-core/video/readers/png.c b/grub-core/video/readers/png.c
-index 61bd64537..0157ff742 100644
+index 61bd645..0157ff7 100644
 --- a/grub-core/video/readers/png.c
 +++ b/grub-core/video/readers/png.c
 @@ -23,6 +23,7 @@

--- a/debian/patches/0086-iso9660-Don-t-leak-memory-on-realloc-failures.patch
+++ b/debian/patches/0086-iso9660-Don-t-leak-memory-on-realloc-failures.patch
@@ -1,4 +1,3 @@
-From 97a798ab10544250c8a11489b505c9daaa8df337 Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Sat, 4 Jul 2020 12:25:09 -0400
 Subject: iso9660: Don't leak memory on realloc() failures
@@ -10,7 +9,7 @@ Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
  1 file changed, 20 insertions(+), 4 deletions(-)
 
 diff --git a/grub-core/fs/iso9660.c b/grub-core/fs/iso9660.c
-index 7ba5b300b..5ec4433b8 100644
+index 7ba5b30..5ec4433 100644
 --- a/grub-core/fs/iso9660.c
 +++ b/grub-core/fs/iso9660.c
 @@ -533,14 +533,20 @@ add_part (struct iterate_dir_ctx *ctx,

--- a/debian/patches/0087-font-Do-not-load-more-than-one-NAME-section.patch
+++ b/debian/patches/0087-font-Do-not-load-more-than-one-NAME-section.patch
@@ -1,4 +1,3 @@
-From 7cacd3c51f800a4d7a0809083539ef0992a1be77 Mon Sep 17 00:00:00 2001
 From: Daniel Kiper <daniel.kiper@oracle.com>
 Date: Tue, 7 Jul 2020 15:36:26 +0200
 Subject: font: Do not load more than one NAME section
@@ -16,7 +15,7 @@ Reviewed-by: Jan Setje-Eilers <jan.setjeeilers@oracle.com>
  1 file changed, 6 insertions(+)
 
 diff --git a/grub-core/font/font.c b/grub-core/font/font.c
-index 5edb477ac..d09bb38d8 100644
+index 5edb477..d09bb38 100644
 --- a/grub-core/font/font.c
 +++ b/grub-core/font/font.c
 @@ -532,6 +532,12 @@ grub_font_load (const char *filename)

--- a/debian/patches/0088-gfxmenu-Fix-double-free-in-load_image.patch
+++ b/debian/patches/0088-gfxmenu-Fix-double-free-in-load_image.patch
@@ -1,4 +1,3 @@
-From 4347248e750371ebf77ed7d1ed43a085a67d8a7c Mon Sep 17 00:00:00 2001
 From: Alexey Makhalov <amakhalov@vmware.com>
 Date: Wed, 8 Jul 2020 20:41:56 +0000
 Subject: gfxmenu: Fix double free in load_image()
@@ -15,7 +14,7 @@ Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/grub-core/gfxmenu/gui_image.c b/grub-core/gfxmenu/gui_image.c
-index 29784ed2d..6b2e976f1 100644
+index 29784ed..6b2e976 100644
 --- a/grub-core/gfxmenu/gui_image.c
 +++ b/grub-core/gfxmenu/gui_image.c
 @@ -195,7 +195,10 @@ load_image (grub_gui_image_t self, const char *path)

--- a/debian/patches/0089-lzma-Make-sure-we-don-t-dereference-past-array.patch
+++ b/debian/patches/0089-lzma-Make-sure-we-don-t-dereference-past-array.patch
@@ -1,4 +1,3 @@
-From e65a84829a8b80bc50dd9ee81816ee03d6505f7c Mon Sep 17 00:00:00 2001
 From: Konrad Rzeszutek Wilk <konrad.wilk@oracle.com>
 Date: Thu, 9 Jul 2020 03:05:23 +0000
 Subject: lzma: Make sure we don't dereference past array
@@ -21,7 +20,7 @@ Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
  1 file changed, 8 insertions(+), 2 deletions(-)
 
 diff --git a/grub-core/lib/LzmaEnc.c b/grub-core/lib/LzmaEnc.c
-index f2ec04a8c..753e56a95 100644
+index f2ec04a..753e56a 100644
 --- a/grub-core/lib/LzmaEnc.c
 +++ b/grub-core/lib/LzmaEnc.c
 @@ -1877,13 +1877,19 @@ static SRes LzmaEnc_CodeOneBlock(CLzmaEnc *p, Bool useLimits, UInt32 maxPackSize

--- a/debian/patches/0090-tftp-Do-not-use-priority-queue.patch
+++ b/debian/patches/0090-tftp-Do-not-use-priority-queue.patch
@@ -1,4 +1,3 @@
-From 57fc628be89b821a557d2e0147b76398ade773b3 Mon Sep 17 00:00:00 2001
 From: Alexey Makhalov <amakhalov@vmware.com>
 Date: Thu, 9 Jul 2020 08:10:40 +0000
 Subject: tftp: Do not use priority queue
@@ -30,11 +29,11 @@ Fixes: CID 73624, CID 96690
 Signed-off-by: Alexey Makhalov <amakhalov@vmware.com>
 Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
 ---
- grub-core/net/tftp.c | 171 ++++++++++++++-----------------------------
+ grub-core/net/tftp.c | 171 ++++++++++++++++-----------------------------------
  1 file changed, 53 insertions(+), 118 deletions(-)
 
 diff --git a/grub-core/net/tftp.c b/grub-core/net/tftp.c
-index a0817a075..e6566fa17 100644
+index a0817a0..e6566fa 100644
 --- a/grub-core/net/tftp.c
 +++ b/grub-core/net/tftp.c
 @@ -25,7 +25,6 @@

--- a/debian/patches/0091-script-Remove-unused-fields-from-grub_script_functio.patch
+++ b/debian/patches/0091-script-Remove-unused-fields-from-grub_script_functio.patch
@@ -1,4 +1,3 @@
-From 71964abaf73fc654b7fae6a2ad9a28bb7a6c8968 Mon Sep 17 00:00:00 2001
 From: Chris Coulson <chris.coulson@canonical.com>
 Date: Fri, 10 Jul 2020 11:21:14 +0100
 Subject: script: Remove unused fields from grub_script_function struct
@@ -10,7 +9,7 @@ Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
  1 file changed, 5 deletions(-)
 
 diff --git a/include/grub/script_sh.h b/include/grub/script_sh.h
-index 360c2be1f..b382bcf09 100644
+index 360c2be..b382bcf 100644
 --- a/include/grub/script_sh.h
 +++ b/include/grub/script_sh.h
 @@ -359,13 +359,8 @@ struct grub_script_function

--- a/debian/patches/0092-script-Avoid-a-use-after-free-when-redefining-a-func.patch
+++ b/debian/patches/0092-script-Avoid-a-use-after-free-when-redefining-a-func.patch
@@ -1,4 +1,3 @@
-From d81ebda4343f20e59ab80b6b3c7257743c4cd76a Mon Sep 17 00:00:00 2001
 From: Chris Coulson <chris.coulson@canonical.com>
 Date: Fri, 10 Jul 2020 14:41:45 +0100
 Subject: script: Avoid a use-after-free when redefining a function during
@@ -27,7 +26,7 @@ Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
  4 files changed, 19 insertions(+), 4 deletions(-)
 
 diff --git a/grub-core/script/execute.c b/grub-core/script/execute.c
-index c8d6806fe..7e028e135 100644
+index c8d6806..7e028e1 100644
 --- a/grub-core/script/execute.c
 +++ b/grub-core/script/execute.c
 @@ -838,7 +838,9 @@ grub_script_function_call (grub_script_function_t func, int argc, char **args)
@@ -41,7 +40,7 @@ index c8d6806fe..7e028e135 100644
    function_return = 0;
    active_loops = loops;
 diff --git a/grub-core/script/function.c b/grub-core/script/function.c
-index d36655e51..3aad04bf9 100644
+index d36655e..3aad04b 100644
 --- a/grub-core/script/function.c
 +++ b/grub-core/script/function.c
 @@ -34,6 +34,7 @@ grub_script_function_create (struct grub_script_arg *functionname_arg,
@@ -76,7 +75,7 @@ index d36655e51..3aad04bf9 100644
    else
      {
 diff --git a/grub-core/script/parser.y b/grub-core/script/parser.y
-index 4f0ab8319..f80b86b6f 100644
+index 4f0ab83..f80b86b 100644
 --- a/grub-core/script/parser.y
 +++ b/grub-core/script/parser.y
 @@ -289,7 +289,8 @@ function: "function" "name"
@@ -90,7 +89,7 @@ index 4f0ab8319..f80b86b6f 100644
  
  	    state->scripts = $<scripts>3;
 diff --git a/include/grub/script_sh.h b/include/grub/script_sh.h
-index b382bcf09..6c48e0751 100644
+index b382bcf..6c48e07 100644
 --- a/include/grub/script_sh.h
 +++ b/include/grub/script_sh.h
 @@ -361,6 +361,8 @@ struct grub_script_function

--- a/debian/patches/0093-hfsplus-fix-two-more-overflows.patch
+++ b/debian/patches/0093-hfsplus-fix-two-more-overflows.patch
@@ -1,4 +1,3 @@
-From b1251e07c18df83097dfe0e59268d7f2b3c0d058 Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Sun, 19 Jul 2020 14:43:31 -0400
 Subject: hfsplus: fix two more overflows
@@ -15,7 +14,7 @@ Reviewed-by: Darren Kenny <darren.kenny@oracle.com>
  1 file changed, 8 insertions(+), 3 deletions(-)
 
 diff --git a/grub-core/fs/hfsplus.c b/grub-core/fs/hfsplus.c
-index dae43becc..9c4e4c88c 100644
+index dae43be..9c4e4c8 100644
 --- a/grub-core/fs/hfsplus.c
 +++ b/grub-core/fs/hfsplus.c
 @@ -31,6 +31,7 @@

--- a/debian/patches/0094-lvm-fix-two-more-potential-data-dependent-alloc-over.patch
+++ b/debian/patches/0094-lvm-fix-two-more-potential-data-dependent-alloc-over.patch
@@ -1,4 +1,3 @@
-From 78a376a9765a539dbd8d09124421156e52e92982 Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Sun, 19 Jul 2020 15:48:20 -0400
 Subject: lvm: fix two more potential data-dependent alloc overflows
@@ -15,7 +14,7 @@ Signed-off-by: Peter Jones <pjones@redhat.com>
  1 file changed, 31 insertions(+), 8 deletions(-)
 
 diff --git a/grub-core/disk/lvm.c b/grub-core/disk/lvm.c
-index d1df640b3..d154f7c01 100644
+index d1df640..d154f7c 100644
 --- a/grub-core/disk/lvm.c
 +++ b/grub-core/disk/lvm.c
 @@ -25,6 +25,7 @@

--- a/debian/patches/0095-efi-fix-some-malformed-device-path-arithmetic-errors.patch
+++ b/debian/patches/0095-efi-fix-some-malformed-device-path-arithmetic-errors.patch
@@ -1,4 +1,3 @@
-From d041c6938aacfe31a692b186928d0e88f4a0a562 Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Sun, 19 Jul 2020 16:53:27 -0400
 Subject: efi: fix some malformed device path arithmetic errors.
@@ -17,14 +16,14 @@ code check for and return errors in these cases.
 
 Signed-off-by: Peter Jones <pjones@redhat.com>
 ---
- grub-core/kern/efi/efi.c           | 67 +++++++++++++++++++++++++-----
- grub-core/loader/efi/chainloader.c | 19 ++++++++-
- grub-core/loader/i386/xnu.c        |  9 ++--
- include/grub/efi/api.h             | 14 ++++---
+ grub-core/kern/efi/efi.c           | 67 ++++++++++++++++++++++++++++++++------
+ grub-core/loader/efi/chainloader.c | 19 +++++++++--
+ grub-core/loader/i386/xnu.c        |  9 ++---
+ include/grub/efi/api.h             | 14 +++++---
  4 files changed, 88 insertions(+), 21 deletions(-)
 
 diff --git a/grub-core/kern/efi/efi.c b/grub-core/kern/efi/efi.c
-index dc31caa21..b1a8b39b4 100644
+index dc31caa..b1a8b39 100644
 --- a/grub-core/kern/efi/efi.c
 +++ b/grub-core/kern/efi/efi.c
 @@ -332,7 +332,7 @@ grub_efi_get_filename (grub_efi_device_path_t *dp0)
@@ -150,7 +149,7 @@ index dc31caa21..b1a8b39b4 100644
    return 0;
  }
 diff --git a/grub-core/loader/efi/chainloader.c b/grub-core/loader/efi/chainloader.c
-index b9a2df34b..f8a34cd49 100644
+index b9a2df3..f8a34cd 100644
 --- a/grub-core/loader/efi/chainloader.c
 +++ b/grub-core/loader/efi/chainloader.c
 @@ -126,6 +126,12 @@ copy_file_path (grub_efi_file_path_device_path_t *fp,
@@ -188,7 +187,7 @@ index b9a2df34b..f8a34cd49 100644
  	break;
        d = GRUB_EFI_NEXT_DEVICE_PATH (d);
 diff --git a/grub-core/loader/i386/xnu.c b/grub-core/loader/i386/xnu.c
-index b7d176b5d..c50cb5410 100644
+index b7d176b..c50cb54 100644
 --- a/grub-core/loader/i386/xnu.c
 +++ b/grub-core/loader/i386/xnu.c
 @@ -516,14 +516,15 @@ grub_cmd_devprop_load (grub_command_t cmd __attribute__ ((unused)),
@@ -212,7 +211,7 @@ index b7d176b5d..c50cb5410 100644
        dev = grub_xnu_devprop_add_device (dpstart, (char *) buf
  					 - (char *) dpstart);
 diff --git a/include/grub/efi/api.h b/include/grub/efi/api.h
-index 9824fbcd0..08bff60b5 100644
+index 9824fbc..08bff60 100644
 --- a/include/grub/efi/api.h
 +++ b/include/grub/efi/api.h
 @@ -640,6 +640,7 @@ typedef struct grub_efi_device_path grub_efi_device_path_protocol_t;

--- a/debian/patches/0096-linuxefi-fail-kernel-validation-without-shim-protoco.patch
+++ b/debian/patches/0096-linuxefi-fail-kernel-validation-without-shim-protoco.patch
@@ -1,4 +1,3 @@
-From b4207b495f61d532cf9524df8ac17e8bf92612f5 Mon Sep 17 00:00:00 2001
 From: Dimitri John Ledkov <xnox@ubuntu.com>
 Date: Wed, 22 Jul 2020 11:31:43 +0100
 Subject: linuxefi: fail kernel validation without shim protocol.
@@ -20,7 +19,7 @@ Signed-off-by: Dimitri John Ledkov <xnox@ubuntu.com>
  4 files changed, 12 insertions(+), 5 deletions(-)
 
 diff --git a/grub-core/loader/arm64/linux.c b/grub-core/loader/arm64/linux.c
-index 1a5296a60..3f5496fc5 100644
+index 1a5296a..3f5496f 100644
 --- a/grub-core/loader/arm64/linux.c
 +++ b/grub-core/loader/arm64/linux.c
 @@ -34,6 +34,7 @@
@@ -52,7 +51,7 @@ index 1a5296a60..3f5496fc5 100644
  
    cmdline_size = grub_loader_cmdline_size (argc, argv) + sizeof (LINUX_IMAGE);
 diff --git a/grub-core/loader/efi/chainloader.c b/grub-core/loader/efi/chainloader.c
-index f8a34cd49..cf89cedf8 100644
+index f8a34cd..cf89ced 100644
 --- a/grub-core/loader/efi/chainloader.c
 +++ b/grub-core/loader/efi/chainloader.c
 @@ -1096,6 +1096,7 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
@@ -64,7 +63,7 @@ index f8a34cd49..cf89cedf8 100644
    grub_file_close (file);
    grub_device_close (dev);
 diff --git a/grub-core/loader/efi/linux.c b/grub-core/loader/efi/linux.c
-index e372b26a1..f6d30bcf7 100644
+index e372b26..f6d30bc 100644
 --- a/grub-core/loader/efi/linux.c
 +++ b/grub-core/loader/efi/linux.c
 @@ -34,6 +34,7 @@ struct grub_efi_shim_lock
@@ -76,7 +75,7 @@ index e372b26a1..f6d30bcf7 100644
  grub_linuxefi_secure_validate (void *data, grub_uint32_t size)
  {
 diff --git a/grub-core/loader/i386/efi/linux.c b/grub-core/loader/i386/efi/linux.c
-index 2929da7a2..e357bf67c 100644
+index 2929da7..e357bf6 100644
 --- a/grub-core/loader/i386/efi/linux.c
 +++ b/grub-core/loader/i386/efi/linux.c
 @@ -199,7 +199,7 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),

--- a/debian/patches/0097-Fix-a-regression-caused-by-efi-fix-some-malformed-de.patch
+++ b/debian/patches/0097-Fix-a-regression-caused-by-efi-fix-some-malformed-de.patch
@@ -1,4 +1,3 @@
-From e00a84a45aea81b6bdef95111ead99db91eb9237 Mon Sep 17 00:00:00 2001
 From: Chris Coulson <chris.coulson@canonical.com>
 Date: Wed, 22 Jul 2020 17:06:04 +0100
 Subject: Fix a regression caused by "efi: fix some malformed device path
@@ -21,7 +20,7 @@ Remove the bogus check, and also propagate errors from copy_file_path.
  1 file changed, 13 insertions(+), 12 deletions(-)
 
 diff --git a/grub-core/loader/efi/chainloader.c b/grub-core/loader/efi/chainloader.c
-index cf89cedf8..d0c53077e 100644
+index cf89ced..d0c5307 100644
 --- a/grub-core/loader/efi/chainloader.c
 +++ b/grub-core/loader/efi/chainloader.c
 @@ -116,7 +116,7 @@ grub_chainloader_boot (void)

--- a/debian/patches/0098-efi-Fix-use-after-free-in-halt-reboot-path.patch
+++ b/debian/patches/0098-efi-Fix-use-after-free-in-halt-reboot-path.patch
@@ -1,4 +1,3 @@
-From 77d24d44ae007d007cd51b02323806fe0fc7dbaa Mon Sep 17 00:00:00 2001
 From: Alexey Makhalov <amakhalov@vmware.com>
 Date: Mon, 20 Jul 2020 23:03:05 +0000
 Subject: efi: Fix use-after-free in halt/reboot path
@@ -52,7 +51,7 @@ Reviewed-by: Darren Kenny <darren.kenny@oracle.com>
  9 files changed, 28 insertions(+), 7 deletions(-)
 
 diff --git a/grub-core/kern/arm/efi/init.c b/grub-core/kern/arm/efi/init.c
-index 06df60e2f..40c3b467f 100644
+index 06df60e..40c3b46 100644
 --- a/grub-core/kern/arm/efi/init.c
 +++ b/grub-core/kern/arm/efi/init.c
 @@ -71,4 +71,7 @@ grub_machine_fini (int flags)
@@ -64,7 +63,7 @@ index 06df60e2f..40c3b467f 100644
 +    grub_efi_memory_fini ();
  }
 diff --git a/grub-core/kern/arm64/efi/init.c b/grub-core/kern/arm64/efi/init.c
-index 6224999ec..5010caefd 100644
+index 6224999..5010cae 100644
 --- a/grub-core/kern/arm64/efi/init.c
 +++ b/grub-core/kern/arm64/efi/init.c
 @@ -57,4 +57,7 @@ grub_machine_fini (int flags)
@@ -76,7 +75,7 @@ index 6224999ec..5010caefd 100644
 +    grub_efi_memory_fini ();
  }
 diff --git a/grub-core/kern/efi/efi.c b/grub-core/kern/efi/efi.c
-index b1a8b39b4..88bbd34ea 100644
+index b1a8b39..88bbd34 100644
 --- a/grub-core/kern/efi/efi.c
 +++ b/grub-core/kern/efi/efi.c
 @@ -157,7 +157,8 @@ grub_efi_get_loaded_image (grub_efi_handle_t image_handle)
@@ -90,7 +89,7 @@ index b1a8b39b4..88bbd34ea 100644
                GRUB_EFI_RESET_COLD, GRUB_EFI_SUCCESS, 0, NULL);
    for (;;) ;
 diff --git a/grub-core/kern/efi/init.c b/grub-core/kern/efi/init.c
-index 3dfdf2d22..2c31847bf 100644
+index 3dfdf2d..2c31847 100644
 --- a/grub-core/kern/efi/init.c
 +++ b/grub-core/kern/efi/init.c
 @@ -80,5 +80,4 @@ grub_efi_fini (void)
@@ -100,7 +99,7 @@ index 3dfdf2d22..2c31847bf 100644
 -  grub_efi_memory_fini ();
  }
 diff --git a/grub-core/kern/i386/efi/init.c b/grub-core/kern/i386/efi/init.c
-index da499aba0..deb2eacd8 100644
+index da499ab..deb2eac 100644
 --- a/grub-core/kern/i386/efi/init.c
 +++ b/grub-core/kern/i386/efi/init.c
 @@ -39,6 +39,11 @@ grub_machine_init (void)
@@ -118,7 +117,7 @@ index da499aba0..deb2eacd8 100644
 +    grub_efi_memory_fini ();
  }
 diff --git a/grub-core/kern/ia64/efi/init.c b/grub-core/kern/ia64/efi/init.c
-index b5ecbd091..f1965571b 100644
+index b5ecbd0..f196557 100644
 --- a/grub-core/kern/ia64/efi/init.c
 +++ b/grub-core/kern/ia64/efi/init.c
 @@ -70,6 +70,11 @@ grub_machine_init (void)
@@ -136,7 +135,7 @@ index b5ecbd091..f1965571b 100644
 +    grub_efi_memory_fini ();
  }
 diff --git a/grub-core/kern/riscv/efi/init.c b/grub-core/kern/riscv/efi/init.c
-index 7eb1969d0..38795fe67 100644
+index 7eb1969..38795fe 100644
 --- a/grub-core/kern/riscv/efi/init.c
 +++ b/grub-core/kern/riscv/efi/init.c
 @@ -73,4 +73,7 @@ grub_machine_fini (int flags)
@@ -148,7 +147,7 @@ index 7eb1969d0..38795fe67 100644
 +    grub_efi_memory_fini ();
  }
 diff --git a/grub-core/lib/efi/halt.c b/grub-core/lib/efi/halt.c
-index 5859f0498..29d413641 100644
+index 5859f04..29d4136 100644
 --- a/grub-core/lib/efi/halt.c
 +++ b/grub-core/lib/efi/halt.c
 @@ -28,7 +28,8 @@
@@ -162,7 +161,7 @@ index 5859f0498..29d413641 100644
      !defined(__riscv)
    grub_acpi_halt ();
 diff --git a/include/grub/loader.h b/include/grub/loader.h
-index 7f82a499f..b20864282 100644
+index 7f82a49..b208642 100644
 --- a/include/grub/loader.h
 +++ b/include/grub/loader.h
 @@ -33,6 +33,7 @@ enum

--- a/debian/patches/0099-chainloader-Avoid-a-double-free-when-validation-fail.patch
+++ b/debian/patches/0099-chainloader-Avoid-a-double-free-when-validation-fail.patch
@@ -1,4 +1,3 @@
-From f850ec1ed3bbd6965b9720ab7e553012b9568cec Mon Sep 17 00:00:00 2001
 From: Chris Coulson <chris.coulson@canonical.com>
 Date: Thu, 23 Jul 2020 14:02:17 +0100
 Subject: chainloader: Avoid a double free when validation fails
@@ -8,7 +7,7 @@ Subject: chainloader: Avoid a double free when validation fails
  1 file changed, 6 insertions(+), 3 deletions(-)
 
 diff --git a/grub-core/loader/efi/chainloader.c b/grub-core/loader/efi/chainloader.c
-index d0c53077e..144a6549d 100644
+index d0c5307..144a654 100644
 --- a/grub-core/loader/efi/chainloader.c
 +++ b/grub-core/loader/efi/chainloader.c
 @@ -1085,6 +1085,9 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),

--- a/debian/patches/0100-relocator-Protect-grub_relocator_alloc_chunk_addr-in.patch
+++ b/debian/patches/0100-relocator-Protect-grub_relocator_alloc_chunk_addr-in.patch
@@ -1,4 +1,3 @@
-From e7b7ab242a2c2ee6601b9f8d06e9bcb30b4e7b00 Mon Sep 17 00:00:00 2001
 From: Alexey Makhalov <amakhalov@vmware.com>
 Date: Wed, 15 Jul 2020 06:42:37 +0000
 Subject: relocator: Protect grub_relocator_alloc_chunk_addr() input args
@@ -19,7 +18,7 @@ Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
  4 files changed, 31 insertions(+), 10 deletions(-)
 
 diff --git a/grub-core/loader/i386/linux.c b/grub-core/loader/i386/linux.c
-index 991eb29db..4e14eb188 100644
+index 991eb29..4e14eb1 100644
 --- a/grub-core/loader/i386/linux.c
 +++ b/grub-core/loader/i386/linux.c
 @@ -36,6 +36,7 @@
@@ -47,7 +46,7 @@ index 991eb29db..4e14eb188 100644
       return err;
      real_mode_mem = get_virtual_current_address (ch);
 diff --git a/grub-core/loader/i386/pc/linux.c b/grub-core/loader/i386/pc/linux.c
-index 3866f048b..81ab3c0c1 100644
+index 3866f04..81ab3c0 100644
 --- a/grub-core/loader/i386/pc/linux.c
 +++ b/grub-core/loader/i386/pc/linux.c
 @@ -36,6 +36,7 @@
@@ -74,7 +73,7 @@ index 3866f048b..81ab3c0c1 100644
    if (! grub_linux_is_bzimage
        && GRUB_LINUX_ZIMAGE_ADDR + grub_linux16_prot_size
 diff --git a/grub-core/loader/i386/xen.c b/grub-core/loader/i386/xen.c
-index 8f662c8ac..cd24874ca 100644
+index 8f662c8..cd24874 100644
 --- a/grub-core/loader/i386/xen.c
 +++ b/grub-core/loader/i386/xen.c
 @@ -41,6 +41,7 @@
@@ -111,7 +110,7 @@ index 8f662c8ac..cd24874ca 100644
      goto fail;
    kern_chunk_src = get_virtual_current_address (ch);
 diff --git a/grub-core/loader/xnu.c b/grub-core/loader/xnu.c
-index 2f0ebd0b8..3fd653993 100644
+index 2f0ebd0..3fd6539 100644
 --- a/grub-core/loader/xnu.c
 +++ b/grub-core/loader/xnu.c
 @@ -35,6 +35,7 @@

--- a/debian/patches/0101-relocator-Protect-grub_relocator_alloc_chunk_align-m.patch
+++ b/debian/patches/0101-relocator-Protect-grub_relocator_alloc_chunk_align-m.patch
@@ -1,4 +1,3 @@
-From 00f5b817bf8220b55aec67904928d130f7a8769c Mon Sep 17 00:00:00 2001
 From: Alexey Makhalov <amakhalov@vmware.com>
 Date: Wed, 8 Jul 2020 01:44:38 +0000
 Subject: relocator: Protect grub_relocator_alloc_chunk_align() max_addr
@@ -19,7 +18,7 @@ It consists of 2 fixes:
 Signed-off-by: Alexey Makhalov <amakhalov@vmware.com>
 Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
 ---
- grub-core/lib/i386/relocator.c        | 28 ++++++++++----------------
+ grub-core/lib/i386/relocator.c        | 28 +++++++++++-----------------
  grub-core/lib/mips/relocator.c        |  6 ++----
  grub-core/lib/powerpc/relocator.c     |  6 ++----
  grub-core/lib/x86_64/efi/relocator.c  |  7 +++----
@@ -28,14 +27,14 @@ Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
  grub-core/loader/i386/pc/linux.c      |  6 ++----
  grub-core/loader/mips/linux.c         |  9 +++------
  grub-core/loader/multiboot.c          |  2 +-
- grub-core/loader/multiboot_elfxx.c    | 10 ++++-----
- grub-core/loader/multiboot_mbi2.c     | 10 ++++-----
+ grub-core/loader/multiboot_elfxx.c    | 10 +++++-----
+ grub-core/loader/multiboot_mbi2.c     | 10 +++++-----
  grub-core/loader/xnu_resume.c         |  2 +-
- include/grub/relocator.h              | 29 +++++++++++++++++++++++++++
+ include/grub/relocator.h              | 29 +++++++++++++++++++++++++++++
  13 files changed, 69 insertions(+), 58 deletions(-)
 
 diff --git a/grub-core/lib/i386/relocator.c b/grub-core/lib/i386/relocator.c
-index 71dd4f0ab..34cbe834f 100644
+index 71dd4f0..34cbe83 100644
 --- a/grub-core/lib/i386/relocator.c
 +++ b/grub-core/lib/i386/relocator.c
 @@ -83,11 +83,10 @@ grub_relocator32_boot (struct grub_relocator *rel,
@@ -88,7 +87,7 @@ index 71dd4f0ab..34cbe834f 100644
      return err;
  
 diff --git a/grub-core/lib/mips/relocator.c b/grub-core/lib/mips/relocator.c
-index 9d5f49cb9..743b213e6 100644
+index 9d5f49c..743b213 100644
 --- a/grub-core/lib/mips/relocator.c
 +++ b/grub-core/lib/mips/relocator.c
 @@ -120,10 +120,8 @@ grub_relocator32_boot (struct grub_relocator *rel,
@@ -105,7 +104,7 @@ index 9d5f49cb9..743b213e6 100644
    if (err)
      return err;
 diff --git a/grub-core/lib/powerpc/relocator.c b/grub-core/lib/powerpc/relocator.c
-index bdf2b111b..8ffb8b686 100644
+index bdf2b11..8ffb8b6 100644
 --- a/grub-core/lib/powerpc/relocator.c
 +++ b/grub-core/lib/powerpc/relocator.c
 @@ -115,10 +115,8 @@ grub_relocator32_boot (struct grub_relocator *rel,
@@ -122,7 +121,7 @@ index bdf2b111b..8ffb8b686 100644
    if (err)
      return err;
 diff --git a/grub-core/lib/x86_64/efi/relocator.c b/grub-core/lib/x86_64/efi/relocator.c
-index 3caef7a40..7d200a125 100644
+index 3caef7a..7d200a1 100644
 --- a/grub-core/lib/x86_64/efi/relocator.c
 +++ b/grub-core/lib/x86_64/efi/relocator.c
 @@ -50,10 +50,9 @@ grub_relocator64_efi_boot (struct grub_relocator *rel,
@@ -140,7 +139,7 @@ index 3caef7a40..7d200a125 100644
      return err;
  
 diff --git a/grub-core/loader/i386/linux.c b/grub-core/loader/i386/linux.c
-index 4e14eb188..04bd78a1f 100644
+index 4e14eb1..04bd78a 100644
 --- a/grub-core/loader/i386/linux.c
 +++ b/grub-core/loader/i386/linux.c
 @@ -184,9 +184,8 @@ allocate_pages (grub_size_t prot_size, grub_size_t *align,
@@ -156,7 +155,7 @@ index 4e14eb188..04bd78a1f 100644
  						    GRUB_RELOCATOR_PREFERENCE_LOW,
  						    1);
 diff --git a/grub-core/loader/i386/multiboot_mbi.c b/grub-core/loader/i386/multiboot_mbi.c
-index ad3cc292f..a67d9d0a8 100644
+index ad3cc29..a67d9d0 100644
 --- a/grub-core/loader/i386/multiboot_mbi.c
 +++ b/grub-core/loader/i386/multiboot_mbi.c
 @@ -466,10 +466,9 @@ grub_multiboot_make_mbi (grub_uint32_t *target)
@@ -174,7 +173,7 @@ index ad3cc292f..a67d9d0a8 100644
      return err;
    ptrorig = get_virtual_current_address (ch);
 diff --git a/grub-core/loader/i386/pc/linux.c b/grub-core/loader/i386/pc/linux.c
-index 81ab3c0c1..6400a5b91 100644
+index 81ab3c0..6400a5b 100644
 --- a/grub-core/loader/i386/pc/linux.c
 +++ b/grub-core/loader/i386/pc/linux.c
 @@ -463,10 +463,8 @@ grub_cmd_initrd (grub_command_t cmd __attribute__ ((unused)),
@@ -191,7 +190,7 @@ index 81ab3c0c1..6400a5b91 100644
        return err;
      initrd_chunk = get_virtual_current_address (ch);
 diff --git a/grub-core/loader/mips/linux.c b/grub-core/loader/mips/linux.c
-index 7b723bf18..e4ed95921 100644
+index 7b723bf..e4ed959 100644
 --- a/grub-core/loader/mips/linux.c
 +++ b/grub-core/loader/mips/linux.c
 @@ -442,12 +442,9 @@ grub_cmd_initrd (grub_command_t cmd __attribute__ ((unused)),
@@ -211,7 +210,7 @@ index 7b723bf18..e4ed95921 100644
      if (err)
        goto fail;
 diff --git a/grub-core/loader/multiboot.c b/grub-core/loader/multiboot.c
-index 3e6ad166d..3e286908d 100644
+index 3e6ad16..3e28690 100644
 --- a/grub-core/loader/multiboot.c
 +++ b/grub-core/loader/multiboot.c
 @@ -404,7 +404,7 @@ grub_cmd_module (grub_command_t cmd __attribute__ ((unused)),
@@ -224,7 +223,7 @@ index 3e6ad166d..3e286908d 100644
  					    GRUB_RELOCATOR_PREFERENCE_NONE, 1);
      if (err)
 diff --git a/grub-core/loader/multiboot_elfxx.c b/grub-core/loader/multiboot_elfxx.c
-index cc6853692..f2318e0d1 100644
+index cc68536..f2318e0 100644
 --- a/grub-core/loader/multiboot_elfxx.c
 +++ b/grub-core/loader/multiboot_elfxx.c
 @@ -109,10 +109,10 @@ CONCAT(grub_multiboot_load_elf, XX) (mbi_load_data_t *mld)
@@ -252,7 +251,7 @@ index cc6853692..f2318e0d1 100644
  						  GRUB_RELOCATOR_PREFERENCE_NONE,
  						  mld->avoid_efi_boot_services);
 diff --git a/grub-core/loader/multiboot_mbi2.c b/grub-core/loader/multiboot_mbi2.c
-index 53da78615..3ec209283 100644
+index 53da786..3ec2092 100644
 --- a/grub-core/loader/multiboot_mbi2.c
 +++ b/grub-core/loader/multiboot_mbi2.c
 @@ -295,10 +295,10 @@ grub_multiboot2_load (grub_file_t file, const char *filename)
@@ -280,7 +279,7 @@ index 53da78615..3ec209283 100644
  					  GRUB_RELOCATOR_PREFERENCE_NONE, 1);
    if (err)
 diff --git a/grub-core/loader/xnu_resume.c b/grub-core/loader/xnu_resume.c
-index 8089804d4..d648ef0cd 100644
+index 8089804..d648ef0 100644
 --- a/grub-core/loader/xnu_resume.c
 +++ b/grub-core/loader/xnu_resume.c
 @@ -129,7 +129,7 @@ grub_xnu_resume (char *imagename)
@@ -293,7 +292,7 @@ index 8089804d4..d648ef0cd 100644
  					    GRUB_XNU_PAGESIZE,
  					    GRUB_RELOCATOR_PREFERENCE_NONE, 0);
 diff --git a/include/grub/relocator.h b/include/grub/relocator.h
-index 24d8672d2..1b3bdd92a 100644
+index 24d8672..1b3bdd9 100644
 --- a/include/grub/relocator.h
 +++ b/include/grub/relocator.h
 @@ -49,6 +49,35 @@ grub_relocator_alloc_chunk_align (struct grub_relocator *rel,

--- a/debian/patches/0102-relocator-Fix-grub_relocator_alloc_chunk_align-top-m.patch
+++ b/debian/patches/0102-relocator-Fix-grub_relocator_alloc_chunk_align-top-m.patch
@@ -1,4 +1,3 @@
-From d798e7dbc56b3c1c8820c58778ab6a6c4a02c986 Mon Sep 17 00:00:00 2001
 From: Alexey Makhalov <amakhalov@vmware.com>
 Date: Fri, 17 Jul 2020 05:17:26 +0000
 Subject: relocator: Fix grub_relocator_alloc_chunk_align() top memory
@@ -26,7 +25,7 @@ Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/grub-core/lib/relocator.c b/grub-core/lib/relocator.c
-index 5847aac36..f2c1944c2 100644
+index 5847aac..f2c1944 100644
 --- a/grub-core/lib/relocator.c
 +++ b/grub-core/lib/relocator.c
 @@ -1386,8 +1386,8 @@ grub_relocator_alloc_chunk_align (struct grub_relocator *rel,

--- a/debian/patches/0103-linux-loader-avoid-overflow-on-initrd-size-calculati.patch
+++ b/debian/patches/0103-linux-loader-avoid-overflow-on-initrd-size-calculati.patch
@@ -1,4 +1,3 @@
-From bf48f82630a969cd24b2e8cac3759d5af958bd1f Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Fri, 24 Jul 2020 13:57:27 -0400
 Subject: linux loader: avoid overflow on initrd size calculation
@@ -9,7 +8,7 @@ Signed-off-by: Peter Jones <pjones@redhat.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/grub-core/loader/linux.c b/grub-core/loader/linux.c
-index 471b214d6..25624ebc1 100644
+index 471b214..25624eb 100644
 --- a/grub-core/loader/linux.c
 +++ b/grub-core/loader/linux.c
 @@ -151,8 +151,8 @@ grub_initrd_init (int argc, char *argv[],

--- a/debian/patches/0104-linux-Fix-integer-overflows-in-initrd-size-handling.patch
+++ b/debian/patches/0104-linux-Fix-integer-overflows-in-initrd-size-handling.patch
@@ -1,4 +1,3 @@
-From 380bd0958d4a608c039655f021c0961223b432a7 Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@debian.org>
 Date: Sat, 25 Jul 2020 12:15:37 +0100
 Subject: linux: Fix integer overflows in initrd size handling
@@ -10,11 +9,11 @@ Fixes: CVE-2020-15707
 Signed-off-by: Colin Watson <cjwatson@debian.org>
 Reviewed-by: Jan Setje-Eilers <jan.setjeeilers@oracle.com>
 ---
- grub-core/loader/linux.c | 74 +++++++++++++++++++++++++++++-----------
+ grub-core/loader/linux.c | 74 +++++++++++++++++++++++++++++++++++-------------
  1 file changed, 54 insertions(+), 20 deletions(-)
 
 diff --git a/grub-core/loader/linux.c b/grub-core/loader/linux.c
-index 25624ebc1..e9f819ee9 100644
+index 25624eb..e9f819e 100644
 --- a/grub-core/loader/linux.c
 +++ b/grub-core/loader/linux.c
 @@ -4,6 +4,7 @@

--- a/debian/patches/0105-efilinux-Fix-integer-overflows-in-grub_cmd_initrd.patch
+++ b/debian/patches/0105-efilinux-Fix-integer-overflows-in-grub_cmd_initrd.patch
@@ -1,4 +1,3 @@
-From fb66356a8062d553baae7d578dc97c944e4ddba7 Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@debian.org>
 Date: Mon, 27 Jul 2020 14:22:12 +0100
 Subject: efilinux: Fix integer overflows in grub_cmd_initrd
@@ -15,7 +14,7 @@ Signed-off-by: Colin Watson <cjwatson@debian.org>
  1 file changed, 7 insertions(+), 2 deletions(-)
 
 diff --git a/grub-core/loader/i386/efi/linux.c b/grub-core/loader/i386/efi/linux.c
-index e357bf67c..381459ce0 100644
+index e357bf6..381459c 100644
 --- a/grub-core/loader/i386/efi/linux.c
 +++ b/grub-core/loader/i386/efi/linux.c
 @@ -28,6 +28,7 @@

--- a/debian/patches/at_keyboard-module-init.patch
+++ b/debian/patches/at_keyboard-module-init.patch
@@ -1,4 +1,3 @@
-From 5365f46e0c28babd3ec09fa2c665b946ac9b3d0f Mon Sep 17 00:00:00 2001
 From: Jeroen Dekkers <jeroen@dekkers.ch>
 Date: Sat, 12 Jan 2019 21:02:18 +0100
 Subject: at_keyboard: initialize keyboard in module init if keyboard is ready
@@ -16,7 +15,7 @@ Patch-Name: at_keyboard-module-init.patch
  1 file changed, 9 insertions(+)
 
 diff --git a/grub-core/term/at_keyboard.c b/grub-core/term/at_keyboard.c
-index f0a986eb1..d4395c201 100644
+index f0a986e..d4395c2 100644
 --- a/grub-core/term/at_keyboard.c
 +++ b/grub-core/term/at_keyboard.c
 @@ -244,6 +244,14 @@ grub_at_keyboard_getkey (struct grub_term_input *term __attribute__ ((unused)))

--- a/debian/patches/bash-completion-drop-have-checks.patch
+++ b/debian/patches/bash-completion-drop-have-checks.patch
@@ -1,4 +1,3 @@
-From c3bac3061438a6308dc0191e72e295957270c755 Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@debian.org>
 Date: Fri, 16 Nov 2018 16:37:02 +0000
 Subject: bash-completion: Drop "have" checks
@@ -12,11 +11,11 @@ Last-Update: 2018-11-16
 
 Patch-Name: bash-completion-drop-have-checks.patch
 ---
- .../bash-completion.d/grub-completion.bash.in | 39 +++++++------------
+ util/bash-completion.d/grub-completion.bash.in | 39 +++++++++-----------------
  1 file changed, 13 insertions(+), 26 deletions(-)
 
 diff --git a/util/bash-completion.d/grub-completion.bash.in b/util/bash-completion.d/grub-completion.bash.in
-index 44bf135b9..d4235e7ef 100644
+index 44bf135..d4235e7 100644
 --- a/util/bash-completion.d/grub-completion.bash.in
 +++ b/util/bash-completion.d/grub-completion.bash.in
 @@ -166,13 +166,11 @@ _grub_set_entry () {

--- a/debian/patches/blacklist-1440x900x32.patch
+++ b/debian/patches/blacklist-1440x900x32.patch
@@ -1,4 +1,3 @@
-From a48eec06d4c5c5d1e808b52c1193044c09d638c2 Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@ubuntu.com>
 Date: Mon, 13 Jan 2014 12:13:11 +0000
 Subject: Blacklist 1440x900x32 from VBE preferred mode handling
@@ -13,7 +12,7 @@ Patch-Name: blacklist-1440x900x32.patch
  1 file changed, 9 insertions(+)
 
 diff --git a/grub-core/video/i386/pc/vbe.c b/grub-core/video/i386/pc/vbe.c
-index b7f911926..4b1bd7d5e 100644
+index b7f9119..4b1bd7d 100644
 --- a/grub-core/video/i386/pc/vbe.c
 +++ b/grub-core/video/i386/pc/vbe.c
 @@ -1054,6 +1054,15 @@ grub_video_vbe_setup (unsigned int width, unsigned int height,

--- a/debian/patches/bootp-new-net_bootp6-command.patch
+++ b/debian/patches/bootp-new-net_bootp6-command.patch
@@ -1,4 +1,3 @@
-From c5375c14deee6e8fd23a018d583495e5c4f95930 Mon Sep 17 00:00:00 2001
 From: Michael Chang <mchang@suse.com>
 Date: Thu, 27 Oct 2016 17:41:04 -0400
 Subject: bootp: New net_bootp6 command
@@ -11,13 +10,13 @@ Signed-off-by: Ken Lin <ken.lin@hpe.com>
 
 Patch-Name: bootp-new-net_bootp6-command.patch
 ---
- grub-core/net/bootp.c | 908 +++++++++++++++++++++++++++++++++++++++++-
- grub-core/net/ip.c    |  39 ++
+ grub-core/net/bootp.c | 908 +++++++++++++++++++++++++++++++++++++++++++++++++-
+ grub-core/net/ip.c    |  39 +++
  include/grub/net.h    |  72 ++++
  3 files changed, 1018 insertions(+), 1 deletion(-)
 
 diff --git a/grub-core/net/bootp.c b/grub-core/net/bootp.c
-index 04cfbb045..21c1824ef 100644
+index 04cfbb0..21c1824 100644
 --- a/grub-core/net/bootp.c
 +++ b/grub-core/net/bootp.c
 @@ -24,6 +24,98 @@
@@ -969,7 +968,7 @@ index 04cfbb045..21c1824ef 100644
 +  grub_unregister_command (cmd_bootp6);
  }
 diff --git a/grub-core/net/ip.c b/grub-core/net/ip.c
-index ea5edf8f1..01410798b 100644
+index ea5edf8..0141079 100644
 --- a/grub-core/net/ip.c
 +++ b/grub-core/net/ip.c
 @@ -239,6 +239,45 @@ handle_dgram (struct grub_net_buff *nb,
@@ -1019,7 +1018,7 @@ index ea5edf8f1..01410798b 100644
        {
  	const struct grub_net_bootp_packet *bootp;
 diff --git a/include/grub/net.h b/include/grub/net.h
-index cc114286e..58cff96d2 100644
+index cc11428..58cff96 100644
 --- a/include/grub/net.h
 +++ b/include/grub/net.h
 @@ -448,6 +448,66 @@ struct grub_net_bootp_packet

--- a/debian/patches/bootp-process-dhcpack-http-boot.patch
+++ b/debian/patches/bootp-process-dhcpack-http-boot.patch
@@ -1,4 +1,3 @@
-From 6e1e440798cf53f89f0e5a177d781f0b3d4bc1ca Mon Sep 17 00:00:00 2001
 From: Michael Chang <mchang@suse.com>
 Date: Thu, 27 Oct 2016 17:42:19 -0400
 Subject: bootp: Add processing DHCPACK packet from HTTP Boot
@@ -19,12 +18,12 @@ Signed-off-by: Ken Lin <ken.lin@hpe.com>
 
 Patch-Name: bootp-process-dhcpack-http-boot.patch
 ---
- grub-core/net/bootp.c | 60 ++++++++++++++++++++++++++++++++++++++++++-
+ grub-core/net/bootp.c | 60 ++++++++++++++++++++++++++++++++++++++++++++++++++-
  include/grub/net.h    |  1 +
  2 files changed, 60 insertions(+), 1 deletion(-)
 
 diff --git a/grub-core/net/bootp.c b/grub-core/net/bootp.c
-index 21c1824ef..558d97ba1 100644
+index 21c1824..558d97b 100644
 --- a/grub-core/net/bootp.c
 +++ b/grub-core/net/bootp.c
 @@ -154,7 +154,7 @@ struct grub_dhcp_request_options
@@ -109,7 +108,7 @@ index 21c1824ef..558d97ba1 100644
        },
        GRUB_NET_BOOTP_END,
 diff --git a/include/grub/net.h b/include/grub/net.h
-index 58cff96d2..b5f9e617e 100644
+index 58cff96..b5f9e61 100644
 --- a/include/grub/net.h
 +++ b/include/grub/net.h
 @@ -523,6 +523,7 @@ enum

--- a/debian/patches/cherry-fix-crash-on-http.patch
+++ b/debian/patches/cherry-fix-crash-on-http.patch
@@ -1,4 +1,3 @@
-From 23f42aa31bed9a6f44f840ea52f5f3e711c19fc0 Mon Sep 17 00:00:00 2001
 From: Gustavo Luiz Duarte <gustavold@linux.vnet.ibm.com>
 Date: Tue, 17 Sep 2019 17:44:58 +0200
 Subject: net: Fix crash on http
@@ -19,7 +18,7 @@ Patch-Name: cherry-fix-crash-on-http.patch
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/grub-core/net/http.c b/grub-core/net/http.c
-index f182d7b87..dfa849e85 100644
+index f182d7b..dfa849e 100644
 --- a/grub-core/net/http.c
 +++ b/grub-core/net/http.c
 @@ -405,7 +405,7 @@ http_establish (struct grub_file *file, grub_off_t offset, int initial)

--- a/debian/patches/cherrypick-lsefisystab-define-smbios3.patch
+++ b/debian/patches/cherrypick-lsefisystab-define-smbios3.patch
@@ -1,4 +1,3 @@
-From afa464aac6511916c73ad10080de8a8f5abd4b69 Mon Sep 17 00:00:00 2001
 From: David Michael <fedora.dm0@gmail.com>
 Date: Fri, 5 Jul 2019 08:47:02 -0400
 Subject: lsefisystab: Define SMBIOS3 entry point structures for EFI
@@ -16,7 +15,7 @@ Patch-Name: cherrypick-lsefisystab-define-smbios3.patch
  2 files changed, 6 insertions(+)
 
 diff --git a/grub-core/commands/efi/lsefisystab.c b/grub-core/commands/efi/lsefisystab.c
-index df1030221..7c039c509 100644
+index df10302..7c039c5 100644
 --- a/grub-core/commands/efi/lsefisystab.c
 +++ b/grub-core/commands/efi/lsefisystab.c
 @@ -48,6 +48,7 @@ static const struct guid_mapping guid_mappings[] =
@@ -28,7 +27,7 @@ index df1030221..7c039c509 100644
      { GRUB_EFI_TIANO_CUSTOM_DECOMPRESS_GUID, "TIANO CUSTOM DECOMPRESS"},
      { GRUB_EFI_TSC_FREQUENCY_GUID, "TSC FREQUENCY"},
 diff --git a/include/grub/efi/api.h b/include/grub/efi/api.h
-index 75befd10e..9824fbcd0 100644
+index 75befd1..9824fbc 100644
 --- a/include/grub/efi/api.h
 +++ b/include/grub/efi/api.h
 @@ -314,6 +314,11 @@

--- a/debian/patches/cherrypick-lsefisystab-show-dtb.patch
+++ b/debian/patches/cherrypick-lsefisystab-show-dtb.patch
@@ -1,4 +1,3 @@
-From f436a1d60f4b29b184f565370f08f794ae2f8518 Mon Sep 17 00:00:00 2001
 From: Heinrich Schuchardt <xypron.glpk@gmx.de>
 Date: Sat, 6 Jul 2019 11:11:02 +0200
 Subject: lsefisystab: Add support for device tree table
@@ -27,7 +26,7 @@ Patch-Name: cherrypick-lsefisystab-show-dtb.patch
  1 file changed, 1 insertion(+)
 
 diff --git a/grub-core/commands/efi/lsefisystab.c b/grub-core/commands/efi/lsefisystab.c
-index 7c039c509..902788250 100644
+index 7c039c5..9027882 100644
 --- a/grub-core/commands/efi/lsefisystab.c
 +++ b/grub-core/commands/efi/lsefisystab.c
 @@ -40,6 +40,7 @@ static const struct guid_mapping guid_mappings[] =

--- a/debian/patches/cherrypick-smbios-module.patch
+++ b/debian/patches/cherrypick-smbios-module.patch
@@ -1,4 +1,3 @@
-From 114a4b5e70bb2705ca3ff414b1bcbb76c4365bf8 Mon Sep 17 00:00:00 2001
 From: David Michael <fedora.dm0@gmail.com>
 Date: Fri, 5 Jul 2019 08:47:09 -0400
 Subject: smbios: Add a module for retrieving SMBIOS information
@@ -19,13 +18,13 @@ Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
 (cherry picked from commit 688023cd0ac4c985fd0e2ec477fcf1ec33a0e49c)
 Patch-Name: cherrypick-smbios-module.patch
 ---
- docs/grub.texi                       |  75 ++++++
+ docs/grub.texi                       |  75 +++++++
  grub-core/Makefile.core.def          |  15 ++
- grub-core/commands/efi/smbios.c      |  61 +++++
- grub-core/commands/i386/pc/smbios.c  |  52 ++++
- grub-core/commands/smbios.c          | 374 +++++++++++++++++++++++++++
+ grub-core/commands/efi/smbios.c      |  61 ++++++
+ grub-core/commands/i386/pc/smbios.c  |  52 +++++
+ grub-core/commands/smbios.c          | 374 +++++++++++++++++++++++++++++++++++
  grub-core/efiemu/i386/pc/cfgtables.c |  15 +-
- include/grub/smbios.h                |  69 +++++
+ include/grub/smbios.h                |  69 +++++++
  7 files changed, 650 insertions(+), 11 deletions(-)
  create mode 100644 grub-core/commands/efi/smbios.c
  create mode 100644 grub-core/commands/i386/pc/smbios.c
@@ -33,7 +32,7 @@ Patch-Name: cherrypick-smbios-module.patch
  create mode 100644 include/grub/smbios.h
 
 diff --git a/docs/grub.texi b/docs/grub.texi
-index 1baa0fa20..d573f32cb 100644
+index 1baa0fa..d573f32 100644
 --- a/docs/grub.texi
 +++ b/docs/grub.texi
 @@ -3976,6 +3976,7 @@ you forget a command, you can run the command @command{help}
@@ -126,7 +125,7 @@ index 1baa0fa20..d573f32cb 100644
  @subsection source
  
 diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
-index 33e75021d..9b20f3335 100644
+index 33e7502..9b20f33 100644
 --- a/grub-core/Makefile.core.def
 +++ b/grub-core/Makefile.core.def
 @@ -1106,6 +1106,21 @@ module = {
@@ -153,7 +152,7 @@ index 33e75021d..9b20f3335 100644
    ieee1275 = commands/ieee1275/suspend.c;
 diff --git a/grub-core/commands/efi/smbios.c b/grub-core/commands/efi/smbios.c
 new file mode 100644
-index 000000000..75202d5aa
+index 0000000..75202d5
 --- /dev/null
 +++ b/grub-core/commands/efi/smbios.c
 @@ -0,0 +1,61 @@
@@ -220,7 +219,7 @@ index 000000000..75202d5aa
 +}
 diff --git a/grub-core/commands/i386/pc/smbios.c b/grub-core/commands/i386/pc/smbios.c
 new file mode 100644
-index 000000000..069d66367
+index 0000000..069d663
 --- /dev/null
 +++ b/grub-core/commands/i386/pc/smbios.c
 @@ -0,0 +1,52 @@
@@ -278,7 +277,7 @@ index 000000000..069d66367
 +}
 diff --git a/grub-core/commands/smbios.c b/grub-core/commands/smbios.c
 new file mode 100644
-index 000000000..7a6a391fc
+index 0000000..7a6a391
 --- /dev/null
 +++ b/grub-core/commands/smbios.c
 @@ -0,0 +1,374 @@
@@ -657,7 +656,7 @@ index 000000000..7a6a391fc
 +  grub_unregister_extcmd (cmd);
 +}
 diff --git a/grub-core/efiemu/i386/pc/cfgtables.c b/grub-core/efiemu/i386/pc/cfgtables.c
-index 492c07c46..e5fffb7d4 100644
+index 492c07c..e5fffb7 100644
 --- a/grub-core/efiemu/i386/pc/cfgtables.c
 +++ b/grub-core/efiemu/i386/pc/cfgtables.c
 @@ -22,11 +22,11 @@
@@ -696,7 +695,7 @@ index 492c07c46..e5fffb7d4 100644
      }
 diff --git a/include/grub/smbios.h b/include/grub/smbios.h
 new file mode 100644
-index 000000000..15ec260b3
+index 0000000..15ec260
 --- /dev/null
 +++ b/include/grub/smbios.h
 @@ -0,0 +1,69 @@

--- a/debian/patches/core-in-fs.patch
+++ b/debian/patches/core-in-fs.patch
@@ -1,4 +1,3 @@
-From d7e4bea95adfdbc80f574e154a62a383bbbeb5d6 Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@debian.org>
 Date: Mon, 13 Jan 2014 12:12:51 +0000
 Subject: Write marker if core.img was written to filesystem
@@ -11,7 +10,7 @@ Patch-Name: core-in-fs.patch
  1 file changed, 8 insertions(+)
 
 diff --git a/util/setup.c b/util/setup.c
-index 6f88f3cc4..fbdf2fcc5 100644
+index 6f88f3c..fbdf2fc 100644
 --- a/util/setup.c
 +++ b/util/setup.c
 @@ -58,6 +58,8 @@

--- a/debian/patches/default-grub-d.patch
+++ b/debian/patches/default-grub-d.patch
@@ -1,4 +1,3 @@
-From c3ad86f659b0a1af2033086101936f3a17e67a0a Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@ubuntu.com>
 Date: Mon, 13 Jan 2014 12:13:10 +0000
 Subject: Read /etc/default/grub.d/*.cfg after /etc/default/grub
@@ -9,12 +8,12 @@ Last-Update: 2014-01-28
 
 Patch-Name: default-grub-d.patch
 ---
- grub-core/osdep/unix/config.c | 114 +++++++++++++++++++++++++++-------
+ grub-core/osdep/unix/config.c | 114 ++++++++++++++++++++++++++++++++++--------
  util/grub-mkconfig.in         |   5 ++
  2 files changed, 98 insertions(+), 21 deletions(-)
 
 diff --git a/grub-core/osdep/unix/config.c b/grub-core/osdep/unix/config.c
-index 65effa9f3..5478030fd 100644
+index 65effa9..5478030 100644
 --- a/grub-core/osdep/unix/config.c
 +++ b/grub-core/osdep/unix/config.c
 @@ -24,6 +24,8 @@
@@ -178,7 +177,7 @@ index 65effa9f3..5478030fd 100644
 +  free (cfgdir);
  }
 diff --git a/util/grub-mkconfig.in b/util/grub-mkconfig.in
-index b506d63bf..d18bf972f 100644
+index b506d63..d18bf97 100644
 --- a/util/grub-mkconfig.in
 +++ b/util/grub-mkconfig.in
 @@ -164,6 +164,11 @@ fi

--- a/debian/patches/disable-floppies.patch
+++ b/debian/patches/disable-floppies.patch
@@ -1,4 +1,3 @@
-From 42e4cfb46a2a617eb7dc1526700ab6015710222e Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@debian.org>
 Date: Mon, 13 Jan 2014 12:12:54 +0000
 Subject: Disable use of floppy devices
@@ -13,7 +12,7 @@ Patch-Name: disable-floppies.patch
  1 file changed, 12 insertions(+)
 
 diff --git a/grub-core/kern/emu/hostdisk.c b/grub-core/kern/emu/hostdisk.c
-index e9ec680cd..8ac523953 100644
+index e9ec680..8ac5239 100644
 --- a/grub-core/kern/emu/hostdisk.c
 +++ b/grub-core/kern/emu/hostdisk.c
 @@ -532,6 +532,18 @@ read_device_map (const char *dev_map)

--- a/debian/patches/dpkg-version-comparison.patch
+++ b/debian/patches/dpkg-version-comparison.patch
@@ -1,4 +1,3 @@
-From 89a5bb08600e06c33e44a14b1997af3efc98782b Mon Sep 17 00:00:00 2001
 From: Robert Millan <rmh@aybabtu.com>
 Date: Mon, 13 Jan 2014 12:12:52 +0000
 Subject: Improve handling of Debian kernel version numbers
@@ -12,7 +11,7 @@ Patch-Name: dpkg-version-comparison.patch
  1 file changed, 4 insertions(+), 3 deletions(-)
 
 diff --git a/util/grub-mkconfig_lib.in b/util/grub-mkconfig_lib.in
-index 0f801cab3..b6606c16e 100644
+index 0f801ca..b6606c1 100644
 --- a/util/grub-mkconfig_lib.in
 +++ b/util/grub-mkconfig_lib.in
 @@ -239,8 +239,9 @@ version_test_numeric ()

--- a/debian/patches/efi-variable-storage-minimise-writes.patch
+++ b/debian/patches/efi-variable-storage-minimise-writes.patch
@@ -1,4 +1,3 @@
-From b18e6318f49373c1018be8b6d34266a009f10ae8 Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@ubuntu.com>
 Date: Mon, 11 Mar 2019 11:17:43 +0000
 Subject: Minimise writes to EFI variable storage
@@ -51,8 +50,8 @@ Patch-Name: efi-variable-storage-minimise-writes.patch
  Makefile.util.def               |  20 ++
  configure.ac                    |  12 +
  grub-core/osdep/efivar.c        |   3 +
- grub-core/osdep/unix/efivar.c   | 508 ++++++++++++++++++++++++++++++++
- grub-core/osdep/unix/platform.c | 100 +------
+ grub-core/osdep/unix/efivar.c   | 508 ++++++++++++++++++++++++++++++++++++++++
+ grub-core/osdep/unix/platform.c | 100 +-------
  include/grub/util/install.h     |   5 +
  util/grub-install.c             |   4 +-
  8 files changed, 562 insertions(+), 95 deletions(-)
@@ -60,7 +59,7 @@ Patch-Name: efi-variable-storage-minimise-writes.patch
  create mode 100644 grub-core/osdep/unix/efivar.c
 
 diff --git a/INSTALL b/INSTALL
-index 8acb40902..342c158e9 100644
+index 8acb409..342c158 100644
 --- a/INSTALL
 +++ b/INSTALL
 @@ -41,6 +41,11 @@ configuring the GRUB.
@@ -76,7 +75,7 @@ index 8acb40902..342c158e9 100644
  
  * libdevmapper 1.02.34 or later (recommended)
 diff --git a/Makefile.util.def b/Makefile.util.def
-index ce133e694..504d1c058 100644
+index ce133e6..504d1c0 100644
 --- a/Makefile.util.def
 +++ b/Makefile.util.def
 @@ -565,6 +565,8 @@ program = {
@@ -180,7 +179,7 @@ index ce133e694..504d1c058 100644
  
  script = {
 diff --git a/configure.ac b/configure.ac
-index e382c7480..883245553 100644
+index e382c74..8832455 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -443,6 +443,18 @@ AC_CHECK_HEADER([util.h], [
@@ -204,7 +203,7 @@ index e382c7480..883245553 100644
    CFLAGS="$HOST_CFLAGS -Wtrampolines -Werror"
 diff --git a/grub-core/osdep/efivar.c b/grub-core/osdep/efivar.c
 new file mode 100644
-index 000000000..d2750e252
+index 0000000..d2750e2
 --- /dev/null
 +++ b/grub-core/osdep/efivar.c
 @@ -0,0 +1,3 @@
@@ -213,7 +212,7 @@ index 000000000..d2750e252
 +#endif
 diff --git a/grub-core/osdep/unix/efivar.c b/grub-core/osdep/unix/efivar.c
 new file mode 100644
-index 000000000..4a58328b4
+index 0000000..4a58328
 --- /dev/null
 +++ b/grub-core/osdep/unix/efivar.c
 @@ -0,0 +1,508 @@
@@ -726,7 +725,7 @@ index 000000000..4a58328b4
 +
 +#endif /* HAVE_EFIVAR */
 diff --git a/grub-core/osdep/unix/platform.c b/grub-core/osdep/unix/platform.c
-index 9c439326a..b561174ea 100644
+index 9c43932..b561174 100644
 --- a/grub-core/osdep/unix/platform.c
 +++ b/grub-core/osdep/unix/platform.c
 @@ -19,15 +19,12 @@
@@ -856,7 +855,7 @@ index 9c439326a..b561174ea 100644
  
  void
 diff --git a/include/grub/util/install.h b/include/grub/util/install.h
-index 8aeb5c4f2..a521f1663 100644
+index 8aeb5c4..a521f16 100644
 --- a/include/grub/util/install.h
 +++ b/include/grub/util/install.h
 @@ -219,6 +219,11 @@ grub_install_get_default_x86_platform (void);
@@ -872,7 +871,7 @@ index 8aeb5c4f2..a521f1663 100644
  grub_install_register_efi (grub_device_t efidir_grub_dev,
  			   const char *efifile_path,
 diff --git a/util/grub-install.c b/util/grub-install.c
-index 4bad8de61..63462e4e0 100644
+index 4bad8de..63462e4 100644
 --- a/util/grub-install.c
 +++ b/util/grub-install.c
 @@ -2084,7 +2084,7 @@ main (int argc, char *argv[])

--- a/debian/patches/efinet-set-dns-from-uefi-proto.patch
+++ b/debian/patches/efinet-set-dns-from-uefi-proto.patch
@@ -1,4 +1,3 @@
-From 5e2600c379b6ef398a18081b65367f0674c935dc Mon Sep 17 00:00:00 2001
 From: Michael Chang <mchang@suse.com>
 Date: Thu, 27 Oct 2016 17:43:21 -0400
 Subject: efinet: Setting DNS server from UEFI protocol
@@ -30,12 +29,12 @@ Signed-off-by: Ken Lin <ken.lin@hpe.com>
 
 Patch-Name: efinet-set-dns-from-uefi-proto.patch
 ---
- grub-core/net/drivers/efi/efinet.c | 163 +++++++++++++++++++++++++++++
- include/grub/efi/api.h             |  76 ++++++++++++++
+ grub-core/net/drivers/efi/efinet.c | 163 +++++++++++++++++++++++++++++++++++++
+ include/grub/efi/api.h             |  76 +++++++++++++++++
  2 files changed, 239 insertions(+)
 
 diff --git a/grub-core/net/drivers/efi/efinet.c b/grub-core/net/drivers/efi/efinet.c
-index 2d3b00f0e..82a28fb6e 100644
+index 2d3b00f..82a28fb 100644
 --- a/grub-core/net/drivers/efi/efinet.c
 +++ b/grub-core/net/drivers/efi/efinet.c
 @@ -30,6 +30,8 @@ GRUB_MOD_LICENSE ("GPLv3+");
@@ -244,7 +243,7 @@ index 2d3b00f0e..82a28fb6e 100644
      }
  
 diff --git a/include/grub/efi/api.h b/include/grub/efi/api.h
-index 664cea37b..75befd10e 100644
+index 664cea3..75befd1 100644
 --- a/include/grub/efi/api.h
 +++ b/include/grub/efi/api.h
 @@ -334,6 +334,16 @@

--- a/debian/patches/efinet-set-network-from-uefi-devpath.patch
+++ b/debian/patches/efinet-set-network-from-uefi-devpath.patch
@@ -1,4 +1,3 @@
-From 521dfb27bc786d0567c97b704381677f57c4cfe4 Mon Sep 17 00:00:00 2001
 From: Michael Chang <mchang@suse.com>
 Date: Thu, 27 Oct 2016 17:43:05 -0400
 Subject: efinet: Setting network from UEFI device path
@@ -29,12 +28,12 @@ Signed-off-by: Ken Lin <ken.lin@hpe.com>
 
 Patch-Name: efinet-set-network-from-uefi-devpath.patch
 ---
- grub-core/net/drivers/efi/efinet.c | 268 ++++++++++++++++++++++++++++-
+ grub-core/net/drivers/efi/efinet.c | 268 +++++++++++++++++++++++++++++++++++--
  include/grub/efi/api.h             |  11 ++
  2 files changed, 270 insertions(+), 9 deletions(-)
 
 diff --git a/grub-core/net/drivers/efi/efinet.c b/grub-core/net/drivers/efi/efinet.c
-index fc90415f2..2d3b00f0e 100644
+index fc90415..2d3b00f 100644
 --- a/grub-core/net/drivers/efi/efinet.c
 +++ b/grub-core/net/drivers/efi/efinet.c
 @@ -23,6 +23,7 @@
@@ -358,7 +357,7 @@ index fc90415f2..2d3b00f0e 100644
    }
  }
 diff --git a/include/grub/efi/api.h b/include/grub/efi/api.h
-index ca6cdc159..664cea37b 100644
+index ca6cdc1..664cea3 100644
 --- a/include/grub/efi/api.h
 +++ b/include/grub/efi/api.h
 @@ -825,6 +825,8 @@ struct grub_efi_ipv4_device_path

--- a/debian/patches/efinet-uefi-ipv6-pxe-support.patch
+++ b/debian/patches/efinet-uefi-ipv6-pxe-support.patch
@@ -1,4 +1,3 @@
-From efa94cf400cddc721b15210e46471c867cf727e1 Mon Sep 17 00:00:00 2001
 From: Michael Chang <mchang@suse.com>
 Date: Thu, 27 Oct 2016 17:41:21 -0400
 Subject: efinet: UEFI IPv6 PXE support
@@ -12,12 +11,12 @@ Signed-off-by: Ken Lin <ken.lin@hpe.com>
 
 Patch-Name: efinet-uefi-ipv6-pxe-support.patch
 ---
- grub-core/net/drivers/efi/efinet.c | 24 ++++++++++---
- include/grub/efi/api.h             | 55 +++++++++++++++++++++++++++++-
+ grub-core/net/drivers/efi/efinet.c | 24 +++++++++++++----
+ include/grub/efi/api.h             | 55 +++++++++++++++++++++++++++++++++++++-
  2 files changed, 73 insertions(+), 6 deletions(-)
 
 diff --git a/grub-core/net/drivers/efi/efinet.c b/grub-core/net/drivers/efi/efinet.c
-index 5388f952b..fc90415f2 100644
+index 5388f95..fc90415 100644
 --- a/grub-core/net/drivers/efi/efinet.c
 +++ b/grub-core/net/drivers/efi/efinet.c
 @@ -378,11 +378,25 @@ grub_efi_net_config_real (grub_efi_handle_t hnd, char **device,
@@ -52,7 +51,7 @@ index 5388f952b..fc90415f2 100644
    }
  }
 diff --git a/include/grub/efi/api.h b/include/grub/efi/api.h
-index addcbfa8f..ca6cdc159 100644
+index addcbfa..ca6cdc1 100644
 --- a/include/grub/efi/api.h
 +++ b/include/grub/efi/api.h
 @@ -1452,14 +1452,67 @@ typedef struct grub_efi_simple_text_output_interface grub_efi_simple_text_output

--- a/debian/patches/gettext-quiet.patch
+++ b/debian/patches/gettext-quiet.patch
@@ -1,4 +1,3 @@
-From 02b91d62746f4bde8349bbd605b18fb354a85048 Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@ubuntu.com>
 Date: Mon, 13 Jan 2014 12:13:02 +0000
 Subject: Silence error messages when translations are unavailable
@@ -13,7 +12,7 @@ Patch-Name: gettext-quiet.patch
  1 file changed, 5 insertions(+)
 
 diff --git a/grub-core/gettext/gettext.c b/grub-core/gettext/gettext.c
-index 4d02e62c1..2a19389f2 100644
+index 4d02e62..2a19389 100644
 --- a/grub-core/gettext/gettext.c
 +++ b/grub-core/gettext/gettext.c
 @@ -427,6 +427,11 @@ grub_gettext_init_ext (struct grub_gettext_context *ctx,

--- a/debian/patches/gfxpayload-dynamic.patch
+++ b/debian/patches/gfxpayload-dynamic.patch
@@ -1,4 +1,3 @@
-From 40e9945c86cb9ea3d2a23789e7cdbce9905387e1 Mon Sep 17 00:00:00 2001
 From: Evan Broder <evan@ebroder.net>
 Date: Mon, 13 Jan 2014 12:13:29 +0000
 Subject: Add configure option to enable gfxpayload=keep dynamically
@@ -13,17 +12,17 @@ Last-Update: 2019-05-25
 
 Patch-Name: gfxpayload-dynamic.patch
 ---
- configure.ac                         |  11 ++
+ configure.ac                         |  11 +++
  grub-core/Makefile.core.def          |   8 ++
- grub-core/commands/i386/pc/hwmatch.c | 146 +++++++++++++++++++++++++++
+ grub-core/commands/i386/pc/hwmatch.c | 146 +++++++++++++++++++++++++++++++++++
  include/grub/file.h                  |   1 +
- util/grub.d/10_linux.in              |  37 ++++++-
- util/grub.d/10_linux_zfs.in          |  46 ++++++++-
+ util/grub.d/10_linux.in              |  37 ++++++++-
+ util/grub.d/10_linux_zfs.in          |  46 ++++++++++-
  6 files changed, 243 insertions(+), 6 deletions(-)
  create mode 100644 grub-core/commands/i386/pc/hwmatch.c
 
 diff --git a/configure.ac b/configure.ac
-index 7dda5bb32..dbc429ce0 100644
+index 7dda5bb..dbc429c 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -1879,6 +1879,17 @@ else
@@ -45,7 +44,7 @@ index 7dda5bb32..dbc429ce0 100644
  
  AC_SUBST([FONT_SOURCE])
 diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
-index 474a63e68..aadb4cdff 100644
+index 474a63e..aadb4cd 100644
 --- a/grub-core/Makefile.core.def
 +++ b/grub-core/Makefile.core.def
 @@ -971,6 +971,14 @@ module = {
@@ -65,7 +64,7 @@ index 474a63e68..aadb4cdff 100644
    common = commands/keystatus.c;
 diff --git a/grub-core/commands/i386/pc/hwmatch.c b/grub-core/commands/i386/pc/hwmatch.c
 new file mode 100644
-index 000000000..6de07cecc
+index 0000000..6de07ce
 --- /dev/null
 +++ b/grub-core/commands/i386/pc/hwmatch.c
 @@ -0,0 +1,146 @@
@@ -216,7 +215,7 @@ index 000000000..6de07cecc
 +  grub_unregister_command (cmd);
 +}
 diff --git a/include/grub/file.h b/include/grub/file.h
-index 31567483c..e3c4cae2b 100644
+index 3156748..e3c4cae 100644
 --- a/include/grub/file.h
 +++ b/include/grub/file.h
 @@ -122,6 +122,7 @@ enum grub_file_type
@@ -228,7 +227,7 @@ index 31567483c..e3c4cae2b 100644
      GRUB_FILE_TYPE_LOADENV,
      GRUB_FILE_TYPE_SAVEENV,
 diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
-index 2be66c702..09393c28e 100644
+index 2be66c7..09393c2 100644
 --- a/util/grub.d/10_linux.in
 +++ b/util/grub.d/10_linux.in
 @@ -23,6 +23,7 @@ datarootdir="@datarootdir@"
@@ -290,7 +289,7 @@ index 2be66c702..09393c28e 100644
  # yet, so it's empty. In a submenu it will be equal to '\t' (one tab).
  submenu_indentation=""
 diff --git a/util/grub.d/10_linux_zfs.in b/util/grub.d/10_linux_zfs.in
-index ec4b49d9d..8cd7d1285 100755
+index ec4b49d..8cd7d12 100755
 --- a/util/grub.d/10_linux_zfs.in
 +++ b/util/grub.d/10_linux_zfs.in
 @@ -22,6 +22,7 @@ datarootdir="@datarootdir@"

--- a/debian/patches/gfxpayload-keep-default.patch
+++ b/debian/patches/gfxpayload-keep-default.patch
@@ -1,4 +1,3 @@
-From 6b3668640698cff6e0f57bba665a594c11f02841 Mon Sep 17 00:00:00 2001
 From: Didier Roche <didrocks@ubuntu.com>
 Date: Tue, 31 Mar 2020 15:09:45 +0200
 Subject: Disable gfxpayload=keep by default
@@ -24,7 +23,7 @@ Patch-Name: gfxpayload-keep-default.patch
  2 files changed, 8 deletions(-)
 
 diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
-index a75096609..f839b3b55 100644
+index a750966..f839b3b 100644
 --- a/util/grub.d/10_linux.in
 +++ b/util/grub.d/10_linux.in
 @@ -118,10 +118,6 @@ linux_entry ()
@@ -39,7 +38,7 @@ index a75096609..f839b3b55 100644
        if [ "x$GRUB_GFXPAYLOAD_LINUX" != xtext ]; then
  	  echo "	load_video" | sed "s/^/$submenu_indentation/"
 diff --git a/util/grub.d/10_linux_zfs.in b/util/grub.d/10_linux_zfs.in
-index 5ec65fa94..b24587f0a 100755
+index 5ec65fa..b24587f 100755
 --- a/util/grub.d/10_linux_zfs.in
 +++ b/util/grub.d/10_linux_zfs.in
 @@ -744,10 +744,6 @@ zfs_linux_entry () {

--- a/debian/patches/grub-install-backup-and-restore.patch
+++ b/debian/patches/grub-install-backup-and-restore.patch
@@ -1,4 +1,3 @@
-From 378cc55cc167c93dadbe11b03e688521cc489b3e Mon Sep 17 00:00:00 2001
 From: Dimitri John Ledkov <xnox@ubuntu.com>
 Date: Wed, 19 Aug 2020 01:49:09 +0100
 Subject: grub-install: Add backup and restore
@@ -24,11 +23,11 @@ Signed-off-by: Dimitri John Ledkov <xnox@ubuntu.com>
 Patch-Name: grub-install-backup-and-restore.patch
 ---
  configure.ac               |   2 +-
- util/grub-install-common.c | 105 +++++++++++++++++++++++++++++++------
+ util/grub-install-common.c | 105 ++++++++++++++++++++++++++++++++++++++-------
  2 files changed, 91 insertions(+), 16 deletions(-)
 
 diff --git a/configure.ac b/configure.ac
-index 1819188f9..6a88b9b0c 100644
+index 1819188..6a88b9b 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -420,7 +420,7 @@ else
@@ -41,7 +40,7 @@ index 1819188f9..6a88b9b0c 100644
  
  # glibc 2.25 still includes sys/sysmacros.h in sys/types.h but emits deprecation
 diff --git a/util/grub-install-common.c b/util/grub-install-common.c
-index 447504d3f..61f9075bc 100644
+index 447504d..61f9075 100644
 --- a/util/grub-install-common.c
 +++ b/util/grub-install-common.c
 @@ -185,38 +185,113 @@ grub_install_mkdir_p (const char *dst)

--- a/debian/patches/grub-install-pvxen-paths.patch
+++ b/debian/patches/grub-install-pvxen-paths.patch
@@ -1,4 +1,3 @@
-From 66bbce074947abe680475dacfb1cde35b7c17ef3 Mon Sep 17 00:00:00 2001
 From: Ian Campbell <ijc@hellion.org.uk>
 Date: Sat, 6 Sep 2014 12:20:12 +0100
 Subject: grub-install: Install PV Xen binaries into the upstream specified
@@ -20,15 +19,12 @@ Forwarded: http://lists.gnu.org/archive/html/grub-devel/2014-10/msg00041.html
 Last-Update: 2014-10-24
 
 Patch-Name: grub-install-pvxen-paths.patch
-
----
-v2: Respect bootdir, create /boot/xen as needed.
 ---
  util/grub-install.c | 24 ++++++++++++++++++++++--
  1 file changed, 22 insertions(+), 2 deletions(-)
 
 diff --git a/util/grub-install.c b/util/grub-install.c
-index 70d6700de..64c292383 100644
+index 70d6700..64c2923 100644
 --- a/util/grub-install.c
 +++ b/util/grub-install.c
 @@ -2058,6 +2058,28 @@ main (int argc, char *argv[])

--- a/debian/patches/grub-legacy-0-based-partitions.patch
+++ b/debian/patches/grub-legacy-0-based-partitions.patch
@@ -1,4 +1,3 @@
-From fbb34837e1b3185dd2a55d8aeb9b23a8fcc50d54 Mon Sep 17 00:00:00 2001
 From: Robert Millan <rmh@aybabtu.com>
 Date: Mon, 13 Jan 2014 12:12:53 +0000
 Subject: Support running grub-probe in grub-legacy's update-grub
@@ -13,7 +12,7 @@ Patch-Name: grub-legacy-0-based-partitions.patch
  1 file changed, 14 insertions(+)
 
 diff --git a/util/getroot.c b/util/getroot.c
-index 847406fba..cdd41153c 100644
+index 847406f..cdd4115 100644
 --- a/util/getroot.c
 +++ b/util/getroot.c
 @@ -245,6 +245,20 @@ find_partition (grub_disk_t dsk __attribute__ ((unused)),

--- a/debian/patches/grub.cfg-400.patch
+++ b/debian/patches/grub.cfg-400.patch
@@ -1,4 +1,3 @@
-From e0ceb93ec1feab2b084f58d98f8c865847354254 Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@debian.org>
 Date: Mon, 13 Jan 2014 12:12:55 +0000
 Subject: Make grub.cfg world-readable if it contains no passwords
@@ -9,7 +8,7 @@ Patch-Name: grub.cfg-400.patch
  1 file changed, 4 insertions(+)
 
 diff --git a/util/grub-mkconfig.in b/util/grub-mkconfig.in
-index 9f477ff05..45cd4cc54 100644
+index 9f477ff..45cd4cc 100644
 --- a/util/grub-mkconfig.in
 +++ b/util/grub-mkconfig.in
 @@ -276,6 +276,10 @@ for i in "${grub_mkconfig_dir}"/* ; do

--- a/debian/patches/ieee1275-clear-reset.patch
+++ b/debian/patches/ieee1275-clear-reset.patch
@@ -1,4 +1,3 @@
-From 8bec2a413fc7fe8f2a48d37d8127322ebc96971d Mon Sep 17 00:00:00 2001
 From: Paulo Flabiano Smorigo <pfsmorigo@linux.vnet.ibm.com>
 Date: Thu, 25 Sep 2014 18:41:29 -0300
 Subject: Include a text attribute reset in the clear command for ppc
@@ -18,7 +17,7 @@ Patch-Name: ieee1275-clear-reset.patch
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/grub-core/term/terminfo.c b/grub-core/term/terminfo.c
-index d317efa36..63892ad42 100644
+index d317efa..63892ad 100644
 --- a/grub-core/term/terminfo.c
 +++ b/grub-core/term/terminfo.c
 @@ -151,7 +151,7 @@ grub_terminfo_set_current (struct grub_term_output *term,

--- a/debian/patches/ignore-grub_func_test-failures.patch
+++ b/debian/patches/ignore-grub_func_test-failures.patch
@@ -1,4 +1,3 @@
-From a4eaed2b739501db9b1009cd778fc72e9670f9ce Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@debian.org>
 Date: Mon, 13 Jan 2014 12:13:32 +0000
 Subject: Ignore functional test failures for now as they are broken
@@ -14,7 +13,7 @@ Patch-Name: ignore-grub_func_test-failures.patch
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/tests/grub_func_test.in b/tests/grub_func_test.in
-index c67f9e422..728cd6e06 100644
+index c67f9e4..728cd6e 100644
 --- a/tests/grub_func_test.in
 +++ b/tests/grub_func_test.in
 @@ -16,6 +16,8 @@ out=`echo all_functional_test | @builddir@/grub-shell --timeout=3600 --files="/b

--- a/debian/patches/insmod-xzio-and-lzopio-on-xen.patch
+++ b/debian/patches/insmod-xzio-and-lzopio-on-xen.patch
@@ -1,4 +1,3 @@
-From c58c9d77ccd16511db098247b5cbba5abcaac99f Mon Sep 17 00:00:00 2001
 From: Ian Campbell <ijc@debian.org>
 Date: Sun, 30 Nov 2014 12:12:52 +0000
 Subject: Arrange to insmod xzio and lzopio when booting a kernel as a Xen
@@ -21,7 +20,7 @@ Patch-Name: insmod-xzio-and-lzopio-on-xen.patch
  2 files changed, 2 insertions(+)
 
 diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
-index 2c418c5ec..85b30084a 100644
+index 2c418c5..85b3008 100644
 --- a/util/grub.d/10_linux.in
 +++ b/util/grub.d/10_linux.in
 @@ -166,6 +166,7 @@ linux_entry ()
@@ -33,7 +32,7 @@ index 2c418c5ec..85b30084a 100644
    if [ x$dirname = x/ ]; then
      if [ -z "${prepare_root_cache}" ]; then
 diff --git a/util/grub.d/10_linux_zfs.in b/util/grub.d/10_linux_zfs.in
-index 4477fa606..4c48abef0 100755
+index 4477fa6..4c48abe 100755
 --- a/util/grub.d/10_linux_zfs.in
 +++ b/util/grub.d/10_linux_zfs.in
 @@ -838,6 +838,7 @@ zfs_linux_entry () {

--- a/debian/patches/install-efi-fallback.patch
+++ b/debian/patches/install-efi-fallback.patch
@@ -1,4 +1,3 @@
-From 8a5b764a450f0d67f940c2ffbe80eae053753c19 Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@ubuntu.com>
 Date: Mon, 13 Jan 2014 12:13:05 +0000
 Subject: Fall back to non-EFI if booted using EFI but -efi is missing
@@ -15,11 +14,11 @@ Last-Update: 2019-05-24
 
 Patch-Name: install-efi-fallback.patch
 ---
- grub-core/osdep/linux/platform.c | 40 ++++++++++++++++++++++++++++----
+ grub-core/osdep/linux/platform.c | 40 +++++++++++++++++++++++++++++++++++-----
  1 file changed, 35 insertions(+), 5 deletions(-)
 
 diff --git a/grub-core/osdep/linux/platform.c b/grub-core/osdep/linux/platform.c
-index e28a79dab..2e7f72086 100644
+index e28a79d..2e7f720 100644
 --- a/grub-core/osdep/linux/platform.c
 +++ b/grub-core/osdep/linux/platform.c
 @@ -19,10 +19,12 @@

--- a/debian/patches/install-efi-ubuntu-flavours.patch
+++ b/debian/patches/install-efi-ubuntu-flavours.patch
@@ -1,4 +1,3 @@
-From 73faf5c430fe03ec081a838af0e96ad4c42ab26f Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@ubuntu.com>
 Date: Mon, 13 Jan 2014 12:13:27 +0000
 Subject: Cope with Kubuntu setting GRUB_DISTRIBUTOR
@@ -17,7 +16,7 @@ Patch-Name: install-efi-ubuntu-flavours.patch
  1 file changed, 2 insertions(+)
 
 diff --git a/util/grub-install.c b/util/grub-install.c
-index e1e40cf2b..f0d59c180 100644
+index e1e40cf..f0d59c1 100644
 --- a/util/grub-install.c
 +++ b/util/grub-install.c
 @@ -1115,6 +1115,8 @@ main (int argc, char *argv[])

--- a/debian/patches/install-locale-langpack.patch
+++ b/debian/patches/install-locale-langpack.patch
@@ -1,4 +1,3 @@
-From 50921522fab0f4ce529b6c7acd6354b1b3cff2b1 Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@ubuntu.com>
 Date: Mon, 13 Jan 2014 12:13:07 +0000
 Subject: Prefer translations from Ubuntu language packs if available
@@ -13,7 +12,7 @@ Patch-Name: install-locale-langpack.patch
  1 file changed, 30 insertions(+), 7 deletions(-)
 
 diff --git a/util/grub-install-common.c b/util/grub-install-common.c
-index ca0ac612a..fdfe2c7ea 100644
+index ca0ac61..fdfe2c7 100644
 --- a/util/grub-install-common.c
 +++ b/util/grub-install-common.c
 @@ -609,17 +609,25 @@ get_localedir (void)

--- a/debian/patches/install-powerpc-machtypes.patch
+++ b/debian/patches/install-powerpc-machtypes.patch
@@ -1,4 +1,3 @@
-From 2b3e762ebb12ce0d5a562dd36d23bca5d78aa61c Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@debian.org>
 Date: Tue, 28 Jan 2014 14:40:02 +0000
 Subject: Port yaboot logic for various powerpc machine types
@@ -17,15 +16,15 @@ Last-Update: 2014-10-15
 Patch-Name: install-powerpc-machtypes.patch
 ---
  grub-core/osdep/basic/platform.c   |  5 +++
- grub-core/osdep/linux/platform.c   | 72 ++++++++++++++++++++++++++++++
- grub-core/osdep/unix/platform.c    | 28 +++++++++---
- grub-core/osdep/windows/platform.c |  6 +++
+ grub-core/osdep/linux/platform.c   | 72 ++++++++++++++++++++++++++++++++++++++
+ grub-core/osdep/unix/platform.c    | 28 +++++++++++----
+ grub-core/osdep/windows/platform.c |  6 ++++
  include/grub/util/install.h        |  3 ++
- util/grub-install.c                | 11 +++++
+ util/grub-install.c                | 11 ++++++
  6 files changed, 119 insertions(+), 6 deletions(-)
 
 diff --git a/grub-core/osdep/basic/platform.c b/grub-core/osdep/basic/platform.c
-index a7dafd85a..6c293ed2d 100644
+index a7dafd8..6c293ed 100644
 --- a/grub-core/osdep/basic/platform.c
 +++ b/grub-core/osdep/basic/platform.c
 @@ -30,3 +30,8 @@ grub_install_get_default_x86_platform (void)
@@ -38,7 +37,7 @@ index a7dafd85a..6c293ed2d 100644
 +  return "generic";
 +}
 diff --git a/grub-core/osdep/linux/platform.c b/grub-core/osdep/linux/platform.c
-index 2e7f72086..5b37366d4 100644
+index 2e7f720..5b37366 100644
 --- a/grub-core/osdep/linux/platform.c
 +++ b/grub-core/osdep/linux/platform.c
 @@ -24,6 +24,7 @@
@@ -125,7 +124,7 @@ index 2e7f72086..5b37366d4 100644
 +  return machtype;
 +}
 diff --git a/grub-core/osdep/unix/platform.c b/grub-core/osdep/unix/platform.c
-index 55b8f4016..9c439326a 100644
+index 55b8f40..9c43932 100644
 --- a/grub-core/osdep/unix/platform.c
 +++ b/grub-core/osdep/unix/platform.c
 @@ -218,13 +218,29 @@ grub_install_register_ieee1275 (int is_prep, const char *install_device,
@@ -165,7 +164,7 @@ index 55b8f4016..9c439326a 100644
  
    free (boot_device);
 diff --git a/grub-core/osdep/windows/platform.c b/grub-core/osdep/windows/platform.c
-index 7eb53fe01..e19a3d9a8 100644
+index 7eb53fe..e19a3d9 100644
 --- a/grub-core/osdep/windows/platform.c
 +++ b/grub-core/osdep/windows/platform.c
 @@ -128,6 +128,12 @@ grub_install_get_default_x86_platform (void)
@@ -182,7 +181,7 @@ index 7eb53fe01..e19a3d9a8 100644
  get_efi_variable (const wchar_t *varname, ssize_t *len)
  {
 diff --git a/include/grub/util/install.h b/include/grub/util/install.h
-index 2631b1074..8aeb5c4f2 100644
+index 2631b10..8aeb5c4 100644
 --- a/include/grub/util/install.h
 +++ b/include/grub/util/install.h
 @@ -216,6 +216,9 @@ grub_install_get_default_arm_platform (void);
@@ -196,7 +195,7 @@ index 2631b1074..8aeb5c4f2 100644
  grub_install_register_efi (grub_device_t efidir_grub_dev,
  			   const char *efifile_path,
 diff --git a/util/grub-install.c b/util/grub-install.c
-index f0d59c180..70d6700de 100644
+index f0d59c1..70d6700 100644
 --- a/util/grub-install.c
 +++ b/util/grub-install.c
 @@ -1177,7 +1177,18 @@ main (int argc, char *argv[])

--- a/debian/patches/install-stage2-confusion.patch
+++ b/debian/patches/install-stage2-confusion.patch
@@ -1,4 +1,3 @@
-From bd93043d187b87d8faa11135f3414d67da95a167 Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@debian.org>
 Date: Mon, 13 Jan 2014 12:12:58 +0000
 Subject: If GRUB Legacy is still around, tell packaging to ignore it
@@ -13,7 +12,7 @@ Patch-Name: install-stage2-confusion.patch
  1 file changed, 14 insertions(+)
 
 diff --git a/util/grub-install.c b/util/grub-install.c
-index 8a55ad4b8..3b4606eef 100644
+index 8a55ad4..3b4606e 100644
 --- a/util/grub-install.c
 +++ b/util/grub-install.c
 @@ -42,6 +42,7 @@

--- a/debian/patches/maybe-quiet.patch
+++ b/debian/patches/maybe-quiet.patch
@@ -1,4 +1,3 @@
-From 139c9faecee68370e4b46d50ca51d0524029212c Mon Sep 17 00:00:00 2001
 From: Didier Roche <didrocks@ubuntu.com>
 Date: Tue, 31 Mar 2020 15:20:15 +0200
 Subject: Add configure option to reduce visual clutter at boot time
@@ -47,7 +46,7 @@ Patch-Name: maybe-quiet.patch
  10 files changed, 118 insertions(+), 8 deletions(-)
 
 diff --git a/config.h.in b/config.h.in
-index 9e8f9911b..d2c4ce8e5 100644
+index 9e8f991..d2c4ce8 100644
 --- a/config.h.in
 +++ b/config.h.in
 @@ -12,6 +12,8 @@
@@ -60,7 +59,7 @@ index 9e8f9911b..d2c4ce8e5 100644
  /* We don't need those.  */
  #define MINILZO_CFG_SKIP_LZO_PTR 1
 diff --git a/configure.ac b/configure.ac
-index 1e5abc67d..ea00ccd69 100644
+index 1e5abc6..ea00ccd 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -1857,6 +1857,17 @@ else
@@ -93,7 +92,7 @@ index 1e5abc67d..ea00ccd69 100644
  echo "*******************************************************"
  ]
 diff --git a/grub-core/boot/i386/pc/boot.S b/grub-core/boot/i386/pc/boot.S
-index 2bd0b2d28..b0c0f2225 100644
+index 2bd0b2d..b0c0f22 100644
 --- a/grub-core/boot/i386/pc/boot.S
 +++ b/grub-core/boot/i386/pc/boot.S
 @@ -19,6 +19,9 @@
@@ -125,7 +124,7 @@ index 2bd0b2d28..b0c0f2225 100644
  	movw	$disk_address_packet, %si
  
 diff --git a/grub-core/boot/i386/pc/diskboot.S b/grub-core/boot/i386/pc/diskboot.S
-index c1addc0df..9b6d7a7ed 100644
+index c1addc0..9b6d7a7 100644
 --- a/grub-core/boot/i386/pc/diskboot.S
 +++ b/grub-core/boot/i386/pc/diskboot.S
 @@ -18,6 +18,9 @@
@@ -205,7 +204,7 @@ index c1addc0df..9b6d7a7ed 100644
  
  notification_step:	.asciz "."
 diff --git a/grub-core/kern/main.c b/grub-core/kern/main.c
-index 9cad0c448..714b63d67 100644
+index 9cad0c4..714b63d 100644
 --- a/grub-core/kern/main.c
 +++ b/grub-core/kern/main.c
 @@ -264,15 +264,25 @@ reclaim_module_space (void)
@@ -248,7 +247,7 @@ index 9cad0c448..714b63d67 100644
    grub_rescue_run ();
  }
 diff --git a/grub-core/kern/rescue_reader.c b/grub-core/kern/rescue_reader.c
-index dcd7d4439..a93524eab 100644
+index dcd7d44..a93524e 100644
 --- a/grub-core/kern/rescue_reader.c
 +++ b/grub-core/kern/rescue_reader.c
 @@ -78,7 +78,9 @@ grub_rescue_read_line (char **line, int cont,
@@ -262,7 +261,7 @@ index dcd7d4439..a93524eab 100644
    while (1)
      {
 diff --git a/grub-core/normal/main.c b/grub-core/normal/main.c
-index 1b03dfd57..0aa389fa1 100644
+index 1b03dfd..0aa389f 100644
 --- a/grub-core/normal/main.c
 +++ b/grub-core/normal/main.c
 @@ -389,6 +389,15 @@ static grub_err_t
@@ -292,7 +291,7 @@ index 1b03dfd57..0aa389fa1 100644
    while (1)
      {
 diff --git a/grub-core/normal/menu.c b/grub-core/normal/menu.c
-index 3611ee9ea..ebf5a0f10 100644
+index 3611ee9..ebf5a0f 100644
 --- a/grub-core/normal/menu.c
 +++ b/grub-core/normal/menu.c
 @@ -827,12 +827,18 @@ run_menu (grub_menu_t menu, int nested, int *auto_boot)
@@ -339,7 +338,7 @@ index 3611ee9ea..ebf5a0f10 100644
        if (auto_boot)
  	grub_menu_execute_with_fallback (menu, e, autobooted,
 diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
-index cb1cc200e..479a8bf4e 100644
+index cb1cc20..479a8bf 100644
 --- a/util/grub.d/10_linux.in
 +++ b/util/grub.d/10_linux.in
 @@ -21,6 +21,7 @@ prefix="@prefix@"
@@ -386,7 +385,7 @@ index cb1cc200e..479a8bf4e 100644
  EOF
    fi
 diff --git a/util/grub.d/10_linux_zfs.in b/util/grub.d/10_linux_zfs.in
-index bd4f1a212..3a0e6d103 100755
+index bd4f1a2..3a0e6d1 100755
 --- a/util/grub.d/10_linux_zfs.in
 +++ b/util/grub.d/10_linux_zfs.in
 @@ -20,6 +20,7 @@ set -e

--- a/debian/patches/mkconfig-loopback.patch
+++ b/debian/patches/mkconfig-loopback.patch
@@ -1,4 +1,3 @@
-From 3883a00c8f4a4f59b6a677622776d5bf51337b65 Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@debian.org>
 Date: Mon, 13 Jan 2014 12:13:00 +0000
 Subject: Handle filesystems loop-mounted on file images
@@ -21,7 +20,7 @@ Patch-Name: mkconfig-loopback.patch
  3 files changed, 34 insertions(+)
 
 diff --git a/util/grub-mkconfig_lib.in b/util/grub-mkconfig_lib.in
-index b6606c16e..b05df554d 100644
+index b6606c1..b05df55 100644
 --- a/util/grub-mkconfig_lib.in
 +++ b/util/grub-mkconfig_lib.in
 @@ -133,6 +133,22 @@ prepare_grub_to_access_device ()
@@ -63,7 +62,7 @@ index b6606c16e..b05df554d 100644
  
  grub_get_device_id ()
 diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
-index f839b3b55..d927b60ae 100644
+index f839b3b..d927b60 100644
 --- a/util/grub.d/10_linux.in
 +++ b/util/grub.d/10_linux.in
 @@ -40,6 +40,11 @@ fi
@@ -79,7 +78,7 @@ index f839b3b55..d927b60ae 100644
  esac
  
 diff --git a/util/grub.d/20_linux_xen.in b/util/grub.d/20_linux_xen.in
-index 96179ea61..9a8d42fb5 100644
+index 96179ea..9a8d42f 100644
 --- a/util/grub.d/20_linux_xen.in
 +++ b/util/grub.d/20_linux_xen.in
 @@ -40,6 +40,11 @@ fi

--- a/debian/patches/mkconfig-mid-upgrade.patch
+++ b/debian/patches/mkconfig-mid-upgrade.patch
@@ -1,4 +1,3 @@
-From 16f168810740a2fd3defa4856ead7b8ded2d1fb5 Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@ubuntu.com>
 Date: Mon, 13 Jan 2014 12:13:03 +0000
 Subject: Bail out if trying to run grub-mkconfig during upgrade to 2.00
@@ -20,7 +19,7 @@ Patch-Name: mkconfig-mid-upgrade.patch
  1 file changed, 7 insertions(+)
 
 diff --git a/util/grub-mkconfig.in b/util/grub-mkconfig.in
-index 45cd4cc54..b506d63bf 100644
+index 45cd4cc..b506d63 100644
 --- a/util/grub-mkconfig.in
 +++ b/util/grub-mkconfig.in
 @@ -102,6 +102,13 @@ do

--- a/debian/patches/mkconfig-nonexistent-loopback.patch
+++ b/debian/patches/mkconfig-nonexistent-loopback.patch
@@ -1,4 +1,3 @@
-From 0a12aab871f0e938738305d89fc1e32915ea7fda Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@ubuntu.com>
 Date: Mon, 13 Jan 2014 12:13:08 +0000
 Subject: Avoid getting confused by inaccessible loop device backing paths
@@ -14,7 +13,7 @@ Patch-Name: mkconfig-nonexistent-loopback.patch
  2 files changed, 6 insertions(+), 5 deletions(-)
 
 diff --git a/util/grub-mkconfig_lib.in b/util/grub-mkconfig_lib.in
-index b05df554d..fe6319abe 100644
+index b05df55..fe6319a 100644
 --- a/util/grub-mkconfig_lib.in
 +++ b/util/grub-mkconfig_lib.in
 @@ -143,7 +143,7 @@ prepare_grub_to_access_device ()
@@ -27,7 +26,7 @@ index b05df554d..fe6319abe 100644
        esac
      ;;
 diff --git a/util/grub.d/30_os-prober.in b/util/grub.d/30_os-prober.in
-index 775ceb2e0..b7e1147c4 100644
+index 775ceb2..b7e1147 100644
 --- a/util/grub.d/30_os-prober.in
 +++ b/util/grub.d/30_os-prober.in
 @@ -219,6 +219,11 @@ EOF

--- a/debian/patches/mkconfig-other-inits.patch
+++ b/debian/patches/mkconfig-other-inits.patch
@@ -1,4 +1,3 @@
-From 22359dec23434867f467cb704aa771fd63e5ecd9 Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@debian.org>
 Date: Sat, 3 Jan 2015 12:04:59 +0000
 Subject: Generate alternative init entries in advanced menu
@@ -18,7 +17,7 @@ Patch-Name: mkconfig-other-inits.patch
  2 files changed, 21 insertions(+)
 
 diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
-index 85b30084a..dff84edea 100644
+index 85b3008..dff84ed 100644
 --- a/util/grub.d/10_linux.in
 +++ b/util/grub.d/10_linux.in
 @@ -32,6 +32,7 @@ export TEXTDOMAIN=@PACKAGE@
@@ -53,7 +52,7 @@ index 85b30084a..dff84edea 100644
      linux_entry "${OS}" "${version}" recovery \
                  "${GRUB_CMDLINE_LINUX_RECOVERY} ${GRUB_CMDLINE_LINUX}"
 diff --git a/util/grub.d/20_linux_xen.in b/util/grub.d/20_linux_xen.in
-index f2ee0532b..81e5f0d7e 100644
+index f2ee053..81e5f0d 100644
 --- a/util/grub.d/20_linux_xen.in
 +++ b/util/grub.d/20_linux_xen.in
 @@ -27,6 +27,7 @@ export TEXTDOMAIN=@PACKAGE@

--- a/debian/patches/mkconfig-recovery-title.patch
+++ b/debian/patches/mkconfig-recovery-title.patch
@@ -1,4 +1,3 @@
-From cc1216264113d2471a5ee5d472358e265fde1ab5 Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@ubuntu.com>
 Date: Mon, 13 Jan 2014 12:13:33 +0000
 Subject: Add GRUB_RECOVERY_TITLE option
@@ -22,7 +21,7 @@ Patch-Name: mkconfig-recovery-title.patch
  8 files changed, 21 insertions(+), 11 deletions(-)
 
 diff --git a/docs/grub.texi b/docs/grub.texi
-index a835d0ae4..3ec35d315 100644
+index a835d0a..3ec35d3 100644
 --- a/docs/grub.texi
 +++ b/docs/grub.texi
 @@ -1536,6 +1536,11 @@ a console is restricted or limited.
@@ -38,7 +37,7 @@ index a835d0ae4..3ec35d315 100644
  
  The following options are still accepted for compatibility with existing
 diff --git a/util/grub-mkconfig.in b/util/grub-mkconfig.in
-index 307214310..9c1da6477 100644
+index 3072143..9c1da64 100644
 --- a/util/grub-mkconfig.in
 +++ b/util/grub-mkconfig.in
 @@ -196,6 +196,10 @@ GRUB_ACTUAL_DEFAULT="$GRUB_DEFAULT"
@@ -63,7 +62,7 @@ index 307214310..9c1da6477 100644
  if test "x${grub_cfg}" != "x"; then
    rm -f "${grub_cfg}.new"
 diff --git a/util/grub.d/10_hurd.in b/util/grub.d/10_hurd.in
-index 59a9a48a2..7fa3a3fbd 100644
+index 59a9a48..7fa3a3f 100644
 --- a/util/grub.d/10_hurd.in
 +++ b/util/grub.d/10_hurd.in
 @@ -88,8 +88,8 @@ hurd_entry () {
@@ -78,7 +77,7 @@ index 59a9a48a2..7fa3a3fbd 100644
  	  title="$(gettext_printf "%s, with Hurd %s" "${OS}" "${kernel_base}")"
  	  oldtitle="$OS using $kernel_base"
 diff --git a/util/grub.d/10_kfreebsd.in b/util/grub.d/10_kfreebsd.in
-index 9d8e8fd85..8301d361a 100644
+index 9d8e8fd..8301d36 100644
 --- a/util/grub.d/10_kfreebsd.in
 +++ b/util/grub.d/10_kfreebsd.in
 @@ -76,7 +76,7 @@ kfreebsd_entry ()
@@ -91,7 +90,7 @@ index 9d8e8fd85..8301d361a 100644
  	  title="$(gettext_printf "%s, with kFreeBSD %s" "${os}" "${version}")"
        fi
 diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
-index cc2dd855a..2c418c5ec 100644
+index cc2dd85..2c418c5 100644
 --- a/util/grub.d/10_linux.in
 +++ b/util/grub.d/10_linux.in
 @@ -130,7 +130,7 @@ linux_entry ()
@@ -104,7 +103,7 @@ index cc2dd855a..2c418c5ec 100644
  	      title="$(gettext_printf "%s, with Linux %s" "${os}" "${version}")" ;;
        esac
 diff --git a/util/grub.d/10_linux_zfs.in b/util/grub.d/10_linux_zfs.in
-index 48a4e6897..4477fa606 100755
+index 48a4e68..4477fa6 100755
 --- a/util/grub.d/10_linux_zfs.in
 +++ b/util/grub.d/10_linux_zfs.in
 @@ -957,7 +957,7 @@ generate_grub_menu() {
@@ -138,7 +137,7 @@ index 48a4e6897..4477fa606 100755
                          fi
  
 diff --git a/util/grub.d/10_netbsd.in b/util/grub.d/10_netbsd.in
-index 874f59969..bb29cc046 100644
+index 874f599..bb29cc0 100644
 --- a/util/grub.d/10_netbsd.in
 +++ b/util/grub.d/10_netbsd.in
 @@ -102,7 +102,7 @@ netbsd_entry ()
@@ -151,7 +150,7 @@ index 874f59969..bb29cc046 100644
  	  title="$(gettext_printf "%s, with kernel %s (via %s)" "${OS}" "$(echo ${kernel} | sed -e 's,^.*/,,')" "${loader}")"
        fi
 diff --git a/util/grub.d/20_linux_xen.in b/util/grub.d/20_linux_xen.in
-index 9a8d42fb5..f2ee0532b 100644
+index 9a8d42f..f2ee053 100644
 --- a/util/grub.d/20_linux_xen.in
 +++ b/util/grub.d/20_linux_xen.in
 @@ -105,7 +105,7 @@ linux_entry ()

--- a/debian/patches/mkconfig-signed-kernel.patch
+++ b/debian/patches/mkconfig-signed-kernel.patch
@@ -1,4 +1,3 @@
-From 16c328eee53e3fe8c24db8c2438a7410755c58db Mon Sep 17 00:00:00 2001
 From: Didier Roche <didrocks@ubuntu.com>
 Date: Tue, 31 Mar 2020 15:17:45 +0200
 Subject: Generate configuration for signed UEFI kernels if available
@@ -13,7 +12,7 @@ Patch-Name: mkconfig-signed-kernel.patch
  2 files changed, 36 insertions(+)
 
 diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
-index 19e4df4ad..cb1cc200e 100644
+index 19e4df4..cb1cc20 100644
 --- a/util/grub.d/10_linux.in
 +++ b/util/grub.d/10_linux.in
 @@ -165,8 +165,16 @@ linux_entry ()
@@ -48,7 +47,7 @@ index 19e4df4ad..cb1cc200e 100644
    basename=`basename $linux`
    dirname=`dirname $linux`
 diff --git a/util/grub.d/10_linux_zfs.in b/util/grub.d/10_linux_zfs.in
-index 7f88e771e..bd4f1a212 100755
+index 7f88e77..bd4f1a2 100755
 --- a/util/grub.d/10_linux_zfs.in
 +++ b/util/grub.d/10_linux_zfs.in
 @@ -339,6 +339,16 @@ try_default_layout_bpool() {

--- a/debian/patches/mkconfig-ubuntu-distributor.patch
+++ b/debian/patches/mkconfig-ubuntu-distributor.patch
@@ -1,4 +1,3 @@
-From 77ada294ae9feca7e4202f454ddf56245eee16bf Mon Sep 17 00:00:00 2001
 From: Mario Limonciello <Mario_Limonciello@dell.com>
 Date: Mon, 13 Jan 2014 12:13:14 +0000
 Subject: Remove GNU/Linux from default distributor string for Ubuntu
@@ -17,7 +16,7 @@ Patch-Name: mkconfig-ubuntu-distributor.patch
  2 files changed, 16 insertions(+), 2 deletions(-)
 
 diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
-index fcd303387..19e4df4ad 100644
+index fcd3033..19e4df4 100644
 --- a/util/grub.d/10_linux.in
 +++ b/util/grub.d/10_linux.in
 @@ -32,7 +32,14 @@ CLASS="--class gnu-linux --class gnu --class os"
@@ -37,7 +36,7 @@ index fcd303387..19e4df4ad 100644
  fi
  
 diff --git a/util/grub.d/10_linux_zfs.in b/util/grub.d/10_linux_zfs.in
-index de4d21590..7f88e771e 100755
+index de4d215..7f88e77 100755
 --- a/util/grub.d/10_linux_zfs.in
 +++ b/util/grub.d/10_linux_zfs.in
 @@ -790,7 +790,14 @@ generate_grub_menu() {

--- a/debian/patches/mkconfig-ubuntu-recovery.patch
+++ b/debian/patches/mkconfig-ubuntu-recovery.patch
@@ -1,9 +1,8 @@
-From 51814873e68db3d990a080f705e6562ef140b416 Mon Sep 17 00:00:00 2001
 From: Didier Roche <didrocks@ubuntu.com>
 Date: Tue, 31 Mar 2020 15:16:36 +0200
 Subject: "single" -> "recovery" when friendly-recovery is installed
 MIME-Version: 1.0
-Content-Type: text/plain; charset=UTF-8
+Content-Type: text/plain; charset="utf-8"
 Content-Transfer-Encoding: 8bit
 
 If configured with --enable-ubuntu-recovery, also set nomodeset for
@@ -24,7 +23,7 @@ Patch-Name: mkconfig-ubuntu-recovery.patch
  4 files changed, 39 insertions(+), 5 deletions(-)
 
 diff --git a/configure.ac b/configure.ac
-index 7656f2434..1e5abc67d 100644
+index 7656f24..1e5abc6 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -1846,6 +1846,17 @@ fi
@@ -46,7 +45,7 @@ index 7656f2434..1e5abc67d 100644
  
  AC_SUBST([FONT_SOURCE])
 diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
-index d927b60ae..fcd303387 100644
+index d927b60..fcd3033 100644
 --- a/util/grub.d/10_linux.in
 +++ b/util/grub.d/10_linux.in
 @@ -20,6 +20,7 @@ set -e
@@ -94,7 +93,7 @@ index d927b60ae..fcd303387 100644
  
    list=`echo $list | tr ' ' '\n' | fgrep -vx "$linux" | tr '\n' ' '`
 diff --git a/util/grub.d/10_linux_zfs.in b/util/grub.d/10_linux_zfs.in
-index b24587f0a..de4d21590 100755
+index b24587f..de4d215 100755
 --- a/util/grub.d/10_linux_zfs.in
 +++ b/util/grub.d/10_linux_zfs.in
 @@ -19,6 +19,7 @@ set -e
@@ -141,7 +140,7 @@ index b24587f0a..de4d21590 100755
      # IFS is set to TAB (ASCII 0x09)
      echo "${menu_metadata}" |
 diff --git a/util/grub.d/30_os-prober.in b/util/grub.d/30_os-prober.in
-index 515a68c7a..775ceb2e0 100644
+index 515a68c..775ceb2 100644
 --- a/util/grub.d/30_os-prober.in
 +++ b/util/grub.d/30_os-prober.in
 @@ -220,7 +220,7 @@ EOF

--- a/debian/patches/mkrescue-efi-modules.patch
+++ b/debian/patches/mkrescue-efi-modules.patch
@@ -1,4 +1,3 @@
-From 20edd1abb590756c35b886849a15d17d80f82170 Mon Sep 17 00:00:00 2001
 From: Mario Limonciello <Mario_Limonciello@dell.com>
 Date: Mon, 13 Jan 2014 12:12:59 +0000
 Subject: Build vfat into EFI boot images
@@ -14,7 +13,7 @@ Patch-Name: mkrescue-efi-modules.patch
  1 file changed, 2 insertions(+)
 
 diff --git a/util/grub-mkrescue.c b/util/grub-mkrescue.c
-index ce2cbc4f1..45d6140d3 100644
+index ce2cbc4..45d6140 100644
 --- a/util/grub-mkrescue.c
 +++ b/util/grub-mkrescue.c
 @@ -750,6 +750,7 @@ main (int argc, char *argv[])

--- a/debian/patches/net-read-bracketed-ipv6-addr.patch
+++ b/debian/patches/net-read-bracketed-ipv6-addr.patch
@@ -1,4 +1,3 @@
-From 370386aaaed787b4b9082cd75f155f1b21350878 Mon Sep 17 00:00:00 2001
 From: Aaron Miller <aaronmiller@fb.com>
 Date: Thu, 27 Oct 2016 17:39:49 -0400
 Subject: net: read bracketed ipv6 addrs and port numbers
@@ -9,14 +8,14 @@ number
 
 Patch-Name: net-read-bracketed-ipv6-addr.patch
 ---
- grub-core/net/http.c | 21 ++++++++--
- grub-core/net/net.c  | 93 +++++++++++++++++++++++++++++++++++++++++---
- grub-core/net/tftp.c |  6 ++-
+ grub-core/net/http.c | 21 +++++++++---
+ grub-core/net/net.c  | 93 ++++++++++++++++++++++++++++++++++++++++++++++++----
+ grub-core/net/tftp.c |  6 +++-
  include/grub/net.h   |  1 +
  4 files changed, 110 insertions(+), 11 deletions(-)
 
 diff --git a/grub-core/net/http.c b/grub-core/net/http.c
-index 5aa4ad3be..f182d7b87 100644
+index 5aa4ad3..f182d7b 100644
 --- a/grub-core/net/http.c
 +++ b/grub-core/net/http.c
 @@ -312,12 +312,14 @@ http_establish (struct grub_file *file, grub_off_t offset, int initial)
@@ -74,7 +73,7 @@ index 5aa4ad3be..f182d7b87 100644
  				  file);
    if (!data->sock)
 diff --git a/grub-core/net/net.c b/grub-core/net/net.c
-index d5d726a31..b917a75d5 100644
+index d5d726a..b917a75 100644
 --- a/grub-core/net/net.c
 +++ b/grub-core/net/net.c
 @@ -437,6 +437,12 @@ parse_ip6 (const char *val, grub_uint64_t *ip, const char **rest)
@@ -211,7 +210,7 @@ index d5d726a31..b917a75d5 100644
  	  }
        }
 diff --git a/grub-core/net/tftp.c b/grub-core/net/tftp.c
-index 7d90bf66e..a0817a075 100644
+index 7d90bf6..a0817a0 100644
 --- a/grub-core/net/tftp.c
 +++ b/grub-core/net/tftp.c
 @@ -314,6 +314,7 @@ tftp_open (struct grub_file *file, const char *filename)
@@ -241,7 +240,7 @@ index 7d90bf66e..a0817a075 100644
    if (!data->sock)
      {
 diff --git a/include/grub/net.h b/include/grub/net.h
-index 4a9069a14..cc114286e 100644
+index 4a9069a..cc11428 100644
 --- a/include/grub/net.h
 +++ b/include/grub/net.h
 @@ -270,6 +270,7 @@ typedef struct grub_net

--- a/debian/patches/no-devicetree-if-secure-boot.patch
+++ b/debian/patches/no-devicetree-if-secure-boot.patch
@@ -1,4 +1,3 @@
-From 7419d200192a1214872a70852200922529baa7b8 Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Wed, 24 Apr 2019 10:03:04 -0400
 Subject: Forbid the "devicetree" command when Secure Boot is enabled.
@@ -17,7 +16,7 @@ Patch-Name: no-devicetree-if-secure-boot.patch
  2 files changed, 20 insertions(+)
 
 diff --git a/grub-core/loader/arm/linux.c b/grub-core/loader/arm/linux.c
-index 51684914c..092e8e307 100644
+index 5168491..092e8e3 100644
 --- a/grub-core/loader/arm/linux.c
 +++ b/grub-core/loader/arm/linux.c
 @@ -30,6 +30,10 @@
@@ -47,7 +46,7 @@ index 51684914c..092e8e307 100644
    if (!dtb)
      return grub_errno;
 diff --git a/grub-core/loader/efi/fdt.c b/grub-core/loader/efi/fdt.c
-index ee9c5592c..f0c2d91be 100644
+index ee9c559..f0c2d91 100644
 --- a/grub-core/loader/efi/fdt.c
 +++ b/grub-core/loader/efi/fdt.c
 @@ -123,6 +123,14 @@ grub_cmd_devicetree (grub_command_t cmd __attribute__ ((unused)),

--- a/debian/patches/no-insmod-on-sb.patch
+++ b/debian/patches/no-insmod-on-sb.patch
@@ -1,4 +1,3 @@
-From df8702b930179447a7ecaf8bb0f9842522967a41 Mon Sep 17 00:00:00 2001
 From: Matthew Garrett <mjg@redhat.com>
 Date: Mon, 13 Jan 2014 12:13:09 +0000
 Subject: Don't permit loading modules on UEFI secure boot
@@ -16,7 +15,7 @@ Patch-Name: no-insmod-on-sb.patch
  3 files changed, 42 insertions(+)
 
 diff --git a/grub-core/kern/dl.c b/grub-core/kern/dl.c
-index 48eb5e7b6..074dfc3c6 100644
+index 48eb5e7..074dfc3 100644
 --- a/grub-core/kern/dl.c
 +++ b/grub-core/kern/dl.c
 @@ -38,6 +38,10 @@
@@ -47,7 +46,7 @@ index 48eb5e7b6..074dfc3c6 100644
  
    file = grub_file_open (filename, GRUB_FILE_TYPE_GRUB_MODULE);
 diff --git a/grub-core/kern/efi/efi.c b/grub-core/kern/efi/efi.c
-index 6e1ceb905..96204e39b 100644
+index 6e1ceb9..96204e3 100644
 --- a/grub-core/kern/efi/efi.c
 +++ b/grub-core/kern/efi/efi.c
 @@ -273,6 +273,34 @@ grub_efi_get_variable (const char *var, const grub_efi_guid_t *guid,
@@ -86,7 +85,7 @@ index 6e1ceb905..96204e39b 100644
  
  /* Search the mods section from the PE32/PE32+ image. This code uses
 diff --git a/include/grub/efi/efi.h b/include/grub/efi/efi.h
-index e90e00dc4..a237952b3 100644
+index e90e00d..a237952 100644
 --- a/include/grub/efi/efi.h
 +++ b/include/grub/efi/efi.h
 @@ -82,6 +82,7 @@ EXPORT_FUNC (grub_efi_set_variable) (const char *var,

--- a/debian/patches/olpc-prefix-hack.patch
+++ b/debian/patches/olpc-prefix-hack.patch
@@ -1,4 +1,3 @@
-From f268916868b7b2a6b0012a23fb6f434eb208b834 Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@debian.org>
 Date: Mon, 13 Jan 2014 12:12:50 +0000
 Subject: Hack prefix for OLPC
@@ -11,7 +10,7 @@ Patch-Name: olpc-prefix-hack.patch
  1 file changed, 11 insertions(+)
 
 diff --git a/grub-core/kern/ieee1275/init.c b/grub-core/kern/ieee1275/init.c
-index d483e35ee..8b089b48d 100644
+index d483e35..8b089b4 100644
 --- a/grub-core/kern/ieee1275/init.c
 +++ b/grub-core/kern/ieee1275/init.c
 @@ -76,6 +76,7 @@ grub_exit (void)

--- a/debian/patches/ppc64el-disable-vsx.patch
+++ b/debian/patches/ppc64el-disable-vsx.patch
@@ -1,4 +1,3 @@
-From 7736a6a5e58402b8f88d053ce2409b2d16262be5 Mon Sep 17 00:00:00 2001
 From: Paulo Flabiano Smorigo <pfsmorigo@linux.vnet.ibm.com>
 Date: Thu, 25 Sep 2014 19:33:39 -0300
 Subject: Disable VSX instruction
@@ -21,7 +20,7 @@ Patch-Name: ppc64el-disable-vsx.patch
  1 file changed, 12 insertions(+)
 
 diff --git a/grub-core/kern/powerpc/ieee1275/startup.S b/grub-core/kern/powerpc/ieee1275/startup.S
-index 21c884b43..de9a9601a 100644
+index 21c884b..de9a960 100644
 --- a/grub-core/kern/powerpc/ieee1275/startup.S
 +++ b/grub-core/kern/powerpc/ieee1275/startup.S
 @@ -20,6 +20,8 @@

--- a/debian/patches/probe-fusionio.patch
+++ b/debian/patches/probe-fusionio.patch
@@ -1,4 +1,3 @@
-From c89a80f695775566c7f184ec19b4ad34f58906bb Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@ubuntu.com>
 Date: Mon, 13 Jan 2014 12:13:31 +0000
 Subject: Probe FusionIO devices
@@ -14,7 +13,7 @@ Patch-Name: probe-fusionio.patch
  2 files changed, 32 insertions(+)
 
 diff --git a/grub-core/osdep/linux/getroot.c b/grub-core/osdep/linux/getroot.c
-index 90d92d3ad..7adc0f30e 100644
+index 90d92d3..7adc0f3 100644
 --- a/grub-core/osdep/linux/getroot.c
 +++ b/grub-core/osdep/linux/getroot.c
 @@ -950,6 +950,19 @@ grub_util_part_to_disk (const char *os_dev, struct stat *st,
@@ -38,7 +37,7 @@ index 90d92d3ad..7adc0f30e 100644
  
    return path;
 diff --git a/util/deviceiter.c b/util/deviceiter.c
-index a4971ef42..dddc50da7 100644
+index a4971ef..dddc50d 100644
 --- a/util/deviceiter.c
 +++ b/util/deviceiter.c
 @@ -383,6 +383,12 @@ get_nvme_disk_name (char *name, int controller, int namespace)

--- a/debian/patches/quick-boot-lvm.patch
+++ b/debian/patches/quick-boot-lvm.patch
@@ -1,8 +1,7 @@
-From 193f060dd7c98d850e81a0b73383ff19c4374d64 Mon Sep 17 00:00:00 2001
 From: Steve Langasek <steve.langasek@ubuntu.com>
 Date: Tue, 30 Oct 2018 15:04:16 -0700
-Subject: If we don't have writable grubenv and we're on EFI, always show the
- menu
+Subject: If we don't have writable grubenv and we're on EFI,
+ always show the menu
 
 If we don't have writable grubenv, recordfail doesn't work, which means our
 quickboot behavior - with a timeout of 0 - leaves the user without a
@@ -26,7 +25,7 @@ Patch-Name: quick-boot-lvm.patch
  1 file changed, 15 insertions(+), 3 deletions(-)
 
 diff --git a/util/grub.d/00_header.in b/util/grub.d/00_header.in
-index 674a76140..b7135b655 100644
+index 674a761..b7135b6 100644
 --- a/util/grub.d/00_header.in
 +++ b/util/grub.d/00_header.in
 @@ -115,7 +115,7 @@ EOF

--- a/debian/patches/quick-boot.patch
+++ b/debian/patches/quick-boot.patch
@@ -1,4 +1,3 @@
-From a34a2ebb74968f6a460fd0f90c545f3e847a3411 Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@ubuntu.com>
 Date: Mon, 13 Jan 2014 12:13:28 +0000
 Subject: Add configure option to bypass boot menu if possible
@@ -23,18 +22,18 @@ Last-Update: 2015-09-04
 
 Patch-Name: quick-boot.patch
 ---
- configure.ac                | 11 ++++++
- docs/grub.texi              | 14 +++++++
- grub-core/normal/menu.c     | 24 ++++++++++++
+ configure.ac                | 11 +++++++
+ docs/grub.texi              | 14 +++++++++
+ grub-core/normal/menu.c     | 24 ++++++++++++++
  util/grub-mkconfig.in       |  3 +-
- util/grub.d/00_header.in    | 77 +++++++++++++++++++++++++++++++------
- util/grub.d/10_linux.in     |  4 ++
+ util/grub.d/00_header.in    | 77 ++++++++++++++++++++++++++++++++++++++-------
+ util/grub.d/10_linux.in     |  4 +++
  util/grub.d/10_linux_zfs.in |  5 +++
- util/grub.d/30_os-prober.in | 21 ++++++++++
+ util/grub.d/30_os-prober.in | 21 +++++++++++++
  8 files changed, 146 insertions(+), 13 deletions(-)
 
 diff --git a/configure.ac b/configure.ac
-index ea00ccd69..7dda5bb32 100644
+index ea00ccd..7dda5bb 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -1868,6 +1868,17 @@ else
@@ -56,7 +55,7 @@ index ea00ccd69..7dda5bb32 100644
  
  AC_SUBST([FONT_SOURCE])
 diff --git a/docs/grub.texi b/docs/grub.texi
-index 87795075a..a835d0ae4 100644
+index 8779507..a835d0a 100644
 --- a/docs/grub.texi
 +++ b/docs/grub.texi
 @@ -1522,6 +1522,20 @@ This option may be set to a list of GRUB module names separated by spaces.
@@ -81,7 +80,7 @@ index 87795075a..a835d0ae4 100644
  
  The following options are still accepted for compatibility with existing
 diff --git a/grub-core/normal/menu.c b/grub-core/normal/menu.c
-index ebf5a0f10..42c82290d 100644
+index ebf5a0f..42c8229 100644
 --- a/grub-core/normal/menu.c
 +++ b/grub-core/normal/menu.c
 @@ -604,6 +604,30 @@ run_menu (grub_menu_t menu, int nested, int *auto_boot)
@@ -116,7 +115,7 @@ index ebf5a0f10..42c82290d 100644
  	{
  	  pos = grub_term_save_pos ();
 diff --git a/util/grub-mkconfig.in b/util/grub-mkconfig.in
-index d18bf972f..307214310 100644
+index d18bf97..3072143 100644
 --- a/util/grub-mkconfig.in
 +++ b/util/grub-mkconfig.in
 @@ -250,7 +250,8 @@ export GRUB_DEFAULT \
@@ -130,7 +129,7 @@ index d18bf972f..307214310 100644
  if test "x${grub_cfg}" != "x"; then
    rm -f "${grub_cfg}.new"
 diff --git a/util/grub.d/00_header.in b/util/grub.d/00_header.in
-index 93a90233e..674a76140 100644
+index 93a9023..674a761 100644
 --- a/util/grub.d/00_header.in
 +++ b/util/grub.d/00_header.in
 @@ -21,6 +21,8 @@ prefix="@prefix@"
@@ -259,7 +258,7 @@ index 93a90233e..674a76140 100644
  EOF
  }
 diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
-index 479a8bf4e..2be66c702 100644
+index 479a8bf..2be66c7 100644
 --- a/util/grub.d/10_linux.in
 +++ b/util/grub.d/10_linux.in
 @@ -22,6 +22,7 @@ exec_prefix="@exec_prefix@"
@@ -281,7 +280,7 @@ index 479a8bf4e..2be66c702 100644
        save_default_entry | grub_add_tab
    fi
 diff --git a/util/grub.d/10_linux_zfs.in b/util/grub.d/10_linux_zfs.in
-index 3a0e6d103..ec4b49d9d 100755
+index 3a0e6d1..ec4b49d 100755
 --- a/util/grub.d/10_linux_zfs.in
 +++ b/util/grub.d/10_linux_zfs.in
 @@ -21,6 +21,7 @@ prefix="@prefix@"
@@ -304,7 +303,7 @@ index 3a0e6d103..ec4b49d9d 100755
          GRUB_SAVEDEFAULT=${GRUB_SAVEDEFAULT:-}
          default_entry="$(save_default_entry)"
 diff --git a/util/grub.d/30_os-prober.in b/util/grub.d/30_os-prober.in
-index 271044f59..da5f28876 100644
+index 271044f..da5f288 100644
 --- a/util/grub.d/30_os-prober.in
 +++ b/util/grub.d/30_os-prober.in
 @@ -20,12 +20,26 @@ set -e

--- a/debian/patches/restore-mkdevicemap.patch
+++ b/debian/patches/restore-mkdevicemap.patch
@@ -1,4 +1,3 @@
-From 9e77654bae1ee822ee7ae4e90e5f043105388ee4 Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@debian.org>
 Date: Mon, 13 Jan 2014 12:13:01 +0000
 Subject: Restore grub-mkdevicemap
@@ -17,9 +16,9 @@ Patch-Name: restore-mkdevicemap.patch
  Makefile.util.def              |   17 +
  docs/man/grub-mkdevicemap.h2m  |    4 +
  include/grub/util/deviceiter.h |   14 +
- util/deviceiter.c              | 1021 ++++++++++++++++++++++++++++++++
+ util/deviceiter.c              | 1021 ++++++++++++++++++++++++++++++++++++++++
  util/devicemap.c               |   13 +
- util/grub-mkdevicemap.c        |  181 ++++++
+ util/grub-mkdevicemap.c        |  181 +++++++
  6 files changed, 1250 insertions(+)
  create mode 100644 docs/man/grub-mkdevicemap.h2m
  create mode 100644 include/grub/util/deviceiter.h
@@ -28,7 +27,7 @@ Patch-Name: restore-mkdevicemap.patch
  create mode 100644 util/grub-mkdevicemap.c
 
 diff --git a/Makefile.util.def b/Makefile.util.def
-index bac85e284..eec1924b0 100644
+index bac85e2..eec1924 100644
 --- a/Makefile.util.def
 +++ b/Makefile.util.def
 @@ -324,6 +324,23 @@ program = {
@@ -57,7 +56,7 @@ index bac85e284..eec1924b0 100644
    installdir = sbin;
 diff --git a/docs/man/grub-mkdevicemap.h2m b/docs/man/grub-mkdevicemap.h2m
 new file mode 100644
-index 000000000..96cd6ee72
+index 0000000..96cd6ee
 --- /dev/null
 +++ b/docs/man/grub-mkdevicemap.h2m
 @@ -0,0 +1,4 @@
@@ -67,7 +66,7 @@ index 000000000..96cd6ee72
 +.BR grub-probe (8)
 diff --git a/include/grub/util/deviceiter.h b/include/grub/util/deviceiter.h
 new file mode 100644
-index 000000000..85374978c
+index 0000000..8537497
 --- /dev/null
 +++ b/include/grub/util/deviceiter.h
 @@ -0,0 +1,14 @@
@@ -87,7 +86,7 @@ index 000000000..85374978c
 +#endif /* ! GRUB_DEVICEITER_MACHINE_UTIL_HEADER */
 diff --git a/util/deviceiter.c b/util/deviceiter.c
 new file mode 100644
-index 000000000..a4971ef42
+index 0000000..a4971ef
 --- /dev/null
 +++ b/util/deviceiter.c
 @@ -0,0 +1,1021 @@
@@ -1114,7 +1113,7 @@ index 000000000..a4971ef42
 +}
 diff --git a/util/devicemap.c b/util/devicemap.c
 new file mode 100644
-index 000000000..c61864420
+index 0000000..c618644
 --- /dev/null
 +++ b/util/devicemap.c
 @@ -0,0 +1,13 @@
@@ -1133,7 +1132,7 @@ index 000000000..c61864420
 +}
 diff --git a/util/grub-mkdevicemap.c b/util/grub-mkdevicemap.c
 new file mode 100644
-index 000000000..c4bbdbf69
+index 0000000..c4bbdbf
 --- /dev/null
 +++ b/util/grub-mkdevicemap.c
 @@ -0,0 +1,181 @@

--- a/debian/patches/rhboot-f34-dont-use-int-for-efi-status.patch
+++ b/debian/patches/rhboot-f34-dont-use-int-for-efi-status.patch
@@ -1,4 +1,3 @@
-From 4224d980b74b26426e445bbeda53ead8b431bb56 Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Mon, 26 Jun 2017 12:44:59 -0400
 Subject: don't use int for efi status
@@ -11,7 +10,7 @@ Patch-Name: rhboot-f34-dont-use-int-for-efi-status.patch
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/grub-core/kern/efi/efi.c b/grub-core/kern/efi/efi.c
-index d4a4be57c..7cf003f71 100644
+index d4a4be5..7cf003f 100644
 --- a/grub-core/kern/efi/efi.c
 +++ b/grub-core/kern/efi/efi.c
 @@ -167,7 +167,7 @@ grub_reboot (void)

--- a/debian/patches/rhboot-f34-make-exit-take-a-return-code.patch
+++ b/debian/patches/rhboot-f34-make-exit-take-a-return-code.patch
@@ -1,4 +1,3 @@
-From a06e6428340c903b28e43909bc3e31bf58bd780e Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Wed, 26 Feb 2014 21:49:12 -0500
 Subject: Make "exit" take a return code.
@@ -30,7 +29,7 @@ Patch-Name: rhboot-f34-make-exit-take-a-return-code.patch
  14 files changed, 48 insertions(+), 21 deletions(-)
 
 diff --git a/grub-core/commands/minicmd.c b/grub-core/commands/minicmd.c
-index 6bbce3128..6d66b7c45 100644
+index 6bbce31..6d66b7c 100644
 --- a/grub-core/commands/minicmd.c
 +++ b/grub-core/commands/minicmd.c
 @@ -179,12 +179,24 @@ grub_mini_cmd_lsmod (struct grub_command *cmd __attribute__ ((unused)),
@@ -63,7 +62,7 @@ index 6bbce3128..6d66b7c45 100644
  }
  
 diff --git a/grub-core/kern/efi/efi.c b/grub-core/kern/efi/efi.c
-index 88bbd34ea..d4a4be57c 100644
+index 88bbd34..d4a4be5 100644
 --- a/grub-core/kern/efi/efi.c
 +++ b/grub-core/kern/efi/efi.c
 @@ -165,11 +165,16 @@ grub_reboot (void)
@@ -86,7 +85,7 @@ index 88bbd34ea..d4a4be57c 100644
  }
  
 diff --git a/grub-core/kern/emu/main.c b/grub-core/kern/emu/main.c
-index 425bb9603..55ea5a11c 100644
+index 425bb96..55ea5a1 100644
 --- a/grub-core/kern/emu/main.c
 +++ b/grub-core/kern/emu/main.c
 @@ -67,7 +67,7 @@ grub_reboot (void)
@@ -99,7 +98,7 @@ index 425bb9603..55ea5a11c 100644
    grub_reboot ();
  }
 diff --git a/grub-core/kern/emu/misc.c b/grub-core/kern/emu/misc.c
-index dfd8a8ec4..0ff13bcaf 100644
+index dfd8a8e..0ff13bc 100644
 --- a/grub-core/kern/emu/misc.c
 +++ b/grub-core/kern/emu/misc.c
 @@ -151,9 +151,10 @@ xasprintf (const char *fmt, ...)
@@ -116,7 +115,7 @@ index dfd8a8ec4..0ff13bcaf 100644
  #endif
  
 diff --git a/grub-core/kern/i386/coreboot/init.c b/grub-core/kern/i386/coreboot/init.c
-index 3314f027f..36f9134b7 100644
+index 3314f02..36f9134 100644
 --- a/grub-core/kern/i386/coreboot/init.c
 +++ b/grub-core/kern/i386/coreboot/init.c
 @@ -41,7 +41,7 @@ extern grub_uint8_t _end[];
@@ -129,7 +128,7 @@ index 3314f027f..36f9134b7 100644
    /* We can't use grub_fatal() in this function.  This would create an infinite
       loop, since grub_fatal() calls grub_abort() which in turn calls grub_exit().  */
 diff --git a/grub-core/kern/i386/qemu/init.c b/grub-core/kern/i386/qemu/init.c
-index 271b6fbfa..9fafe98f0 100644
+index 271b6fb..9fafe98 100644
 --- a/grub-core/kern/i386/qemu/init.c
 +++ b/grub-core/kern/i386/qemu/init.c
 @@ -42,7 +42,7 @@ extern grub_uint8_t _end[];
@@ -142,7 +141,7 @@ index 271b6fbfa..9fafe98f0 100644
    /* We can't use grub_fatal() in this function.  This would create an infinite
       loop, since grub_fatal() calls grub_abort() which in turn calls grub_exit().  */
 diff --git a/grub-core/kern/ieee1275/init.c b/grub-core/kern/ieee1275/init.c
-index 8b089b48d..085a6a33f 100644
+index 8b089b4..085a6a3 100644
 --- a/grub-core/kern/ieee1275/init.c
 +++ b/grub-core/kern/ieee1275/init.c
 @@ -71,7 +71,7 @@ grub_addr_t grub_ieee1275_original_stack;
@@ -155,7 +154,7 @@ index 8b089b48d..085a6a33f 100644
    grub_ieee1275_exit ();
  }
 diff --git a/grub-core/kern/mips/arc/init.c b/grub-core/kern/mips/arc/init.c
-index 3834a1490..86b3a25ec 100644
+index 3834a14..86b3a25 100644
 --- a/grub-core/kern/mips/arc/init.c
 +++ b/grub-core/kern/mips/arc/init.c
 @@ -276,7 +276,7 @@ grub_halt (void)
@@ -168,7 +167,7 @@ index 3834a1490..86b3a25ec 100644
    GRUB_ARC_FIRMWARE_VECTOR->exit ();
  
 diff --git a/grub-core/kern/mips/loongson/init.c b/grub-core/kern/mips/loongson/init.c
-index 7b96531b9..dff598ca7 100644
+index 7b96531..dff598c 100644
 --- a/grub-core/kern/mips/loongson/init.c
 +++ b/grub-core/kern/mips/loongson/init.c
 @@ -304,7 +304,7 @@ grub_halt (void)
@@ -181,7 +180,7 @@ index 7b96531b9..dff598ca7 100644
    grub_halt ();
  }
 diff --git a/grub-core/kern/mips/qemu_mips/init.c b/grub-core/kern/mips/qemu_mips/init.c
-index be88b77d2..8b6c55ffc 100644
+index be88b77..8b6c55f 100644
 --- a/grub-core/kern/mips/qemu_mips/init.c
 +++ b/grub-core/kern/mips/qemu_mips/init.c
 @@ -75,7 +75,7 @@ grub_machine_fini (int flags __attribute__ ((unused)))
@@ -194,7 +193,7 @@ index be88b77d2..8b6c55ffc 100644
    grub_halt ();
  }
 diff --git a/grub-core/kern/misc.c b/grub-core/kern/misc.c
-index 83c068d61..e742f56d2 100644
+index 83c068d..e742f56 100644
 --- a/grub-core/kern/misc.c
 +++ b/grub-core/kern/misc.c
 @@ -1098,9 +1098,18 @@ grub_abort (void)
@@ -218,7 +217,7 @@ index 83c068d61..e742f56d2 100644
  grub_fatal (const char *fmt, ...)
  {
 diff --git a/grub-core/kern/uboot/init.c b/grub-core/kern/uboot/init.c
-index 3e338645c..be2a5be1d 100644
+index 3e33864..be2a5be 100644
 --- a/grub-core/kern/uboot/init.c
 +++ b/grub-core/kern/uboot/init.c
 @@ -39,9 +39,9 @@ extern grub_size_t grub_total_module_size;
@@ -243,7 +242,7 @@ index 3e338645c..be2a5be1d 100644
    else if (ver > API_SIG_VERSION)
      {
 diff --git a/grub-core/kern/xen/init.c b/grub-core/kern/xen/init.c
-index 782ca7295..708b060f3 100644
+index 782ca72..708b060 100644
 --- a/grub-core/kern/xen/init.c
 +++ b/grub-core/kern/xen/init.c
 @@ -584,7 +584,7 @@ grub_machine_init (void)
@@ -256,7 +255,7 @@ index 782ca7295..708b060f3 100644
    struct sched_shutdown arg;
  
 diff --git a/include/grub/misc.h b/include/grub/misc.h
-index ee48eb7a7..f9135b62e 100644
+index ee48eb7..f9135b6 100644
 --- a/include/grub/misc.h
 +++ b/include/grub/misc.h
 @@ -334,7 +334,7 @@ int EXPORT_FUNC(grub_vsnprintf) (char *str, grub_size_t n, const char *fmt,

--- a/debian/patches/rhboot-f34-make-pmtimer-tsc-calibration-fast.patch
+++ b/debian/patches/rhboot-f34-make-pmtimer-tsc-calibration-fast.patch
@@ -1,4 +1,3 @@
-From 74d573a8a3f4281fac069246f011cad56d6eb533 Mon Sep 17 00:00:00 2001
 From: Peter Jones <pjones@redhat.com>
 Date: Tue, 7 Nov 2017 17:12:17 -0500
 Subject: Make pmtimer tsc calibration not take 51 seconds to fail.
@@ -63,11 +62,11 @@ Signed-off-by: Peter Jones <pjones@redhat.com>
 Patch-Name: rhboot-f34-make-pmtimer-tsc-calibration-fast.patch
 (cherry picked from commit ecea6495041ee81331d245cf25ac53d66f07561c)
 ---
- grub-core/kern/i386/tsc_pmtimer.c | 109 ++++++++++++++++++++++++------
+ grub-core/kern/i386/tsc_pmtimer.c | 109 +++++++++++++++++++++++++++++++-------
  1 file changed, 89 insertions(+), 20 deletions(-)
 
 diff --git a/grub-core/kern/i386/tsc_pmtimer.c b/grub-core/kern/i386/tsc_pmtimer.c
-index c9c361699..ca15c3aac 100644
+index c9c3616..ca15c3a 100644
 --- a/grub-core/kern/i386/tsc_pmtimer.c
 +++ b/grub-core/kern/i386/tsc_pmtimer.c
 @@ -28,40 +28,101 @@

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -114,3 +114,4 @@ rhboot-f34-make-exit-take-a-return-code.patch
 rhboot-f34-dont-use-int-for-efi-status.patch
 rhboot-f34-make-pmtimer-tsc-calibration-fast.patch
 cherry-fix-crash-on-http.patch
+ubuntu-add-initrd-less-boot-messages.patch

--- a/debian/patches/skip-grub_cmd_set_date.patch
+++ b/debian/patches/skip-grub_cmd_set_date.patch
@@ -1,4 +1,3 @@
-From 0bd95cc9927bd92aa12a5fa9ba6ffd11ffc8b910 Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@debian.org>
 Date: Sun, 28 Oct 2018 19:45:56 +0000
 Subject: Skip flaky grub_cmd_set_date test
@@ -12,7 +11,7 @@ Patch-Name: skip-grub_cmd_set_date.patch
  1 file changed, 3 insertions(+)
 
 diff --git a/tests/grub_cmd_set_date.in b/tests/grub_cmd_set_date.in
-index aac120a6c..1bb5be4ca 100644
+index aac120a..1bb5be4 100644
 --- a/tests/grub_cmd_set_date.in
 +++ b/tests/grub_cmd_set_date.in
 @@ -1,6 +1,9 @@

--- a/debian/patches/sleep-shift.patch
+++ b/debian/patches/sleep-shift.patch
@@ -1,4 +1,3 @@
-From e731dba24511ce3c9a06923db223ddd337798719 Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@ubuntu.com>
 Date: Mon, 13 Jan 2014 12:13:23 +0000
 Subject: Allow Shift to interrupt 'sleep --interruptible'
@@ -17,7 +16,7 @@ Patch-Name: sleep-shift.patch
  2 files changed, 45 insertions(+), 1 deletion(-)
 
 diff --git a/grub-core/commands/sleep.c b/grub-core/commands/sleep.c
-index e77e7900f..3906b1410 100644
+index e77e790..3906b14 100644
 --- a/grub-core/commands/sleep.c
 +++ b/grub-core/commands/sleep.c
 @@ -46,6 +46,31 @@ do_print (int n)
@@ -62,7 +61,7 @@ index e77e7900f..3906b1410 100644
  
    return 0;
 diff --git a/grub-core/normal/menu.c b/grub-core/normal/menu.c
-index d5e0c79a7..3611ee9ea 100644
+index d5e0c79..3611ee9 100644
 --- a/grub-core/normal/menu.c
 +++ b/grub-core/normal/menu.c
 @@ -615,8 +615,27 @@ run_menu (grub_menu_t menu, int nested, int *auto_boot)

--- a/debian/patches/tftp-rollover-block-counter.patch
+++ b/debian/patches/tftp-rollover-block-counter.patch
@@ -1,4 +1,3 @@
-From c77ec160b81731ccaf557c9db4d74dfe5bbaf81d Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Thu, 10 Sep 2020 17:17:57 +0200
 Subject: tftp: Roll-over block counter to prevent data packets timeouts
@@ -49,7 +48,7 @@ Patch-Name: tftp-rollover-block-counter.patch
  1 file changed, 14 insertions(+), 3 deletions(-)
 
 diff --git a/grub-core/net/tftp.c b/grub-core/net/tftp.c
-index e6566fa17..33c0b8214 100644
+index e6566fa..33c0b82 100644
 --- a/grub-core/net/tftp.c
 +++ b/grub-core/net/tftp.c
 @@ -183,11 +183,22 @@ tftp_receive (grub_net_udp_socket_t sock __attribute__ ((unused)),

--- a/debian/patches/ubuntu-add-devicetree-command-support.patch
+++ b/debian/patches/ubuntu-add-devicetree-command-support.patch
@@ -1,4 +1,3 @@
-From f9072f7a737e9c16338322e84b7a9870977e9377 Mon Sep 17 00:00:00 2001
 From: Dimitri John Ledkov <xnox@ubuntu.com>
 Date: Wed, 22 May 2019 19:57:29 +0100
 Subject: Add devicetree command, if a dtb is present.
@@ -14,7 +13,7 @@ Patch-Name: ubuntu-add-devicetree-command-support.patch
  1 file changed, 19 insertions(+)
 
 diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
-index af1e096bd..bbf5d73e3 100644
+index af1e096..bbf5d73 100644
 --- a/util/grub.d/10_linux.in
 +++ b/util/grub.d/10_linux.in
 @@ -254,6 +254,17 @@ EOF

--- a/debian/patches/ubuntu-add-initrd-less-boot-fallback.patch
+++ b/debian/patches/ubuntu-add-initrd-less-boot-fallback.patch
@@ -1,4 +1,3 @@
-From a22b12544d06eaffb70fda93e724f47b3face92e Mon Sep 17 00:00:00 2001
 From: Chris Glass <chris.glass@canonical.com>
 Date: Fri, 9 Mar 2018 13:47:07 +0100
 Subject: UBUNTU: Added initrd-less boot capabilities.
@@ -11,15 +10,15 @@ Signed-off-by: Steve Langasek <steve.langasek@canonical.com>
 Patch-Name: ubuntu-add-initrd-less-boot-fallback.patch
 ---
  Makefile.am                  |  3 ++
- configure.ac                 | 10 ++++++
- grub-initrd-fallback.service | 13 +++++++
- util/grub.d/00_header.in     | 27 ++++++++++++++
- util/grub.d/10_linux.in      | 68 +++++++++++++++++++++++++++---------
- 5 files changed, 105 insertions(+), 16 deletions(-)
+ configure.ac                 | 10 +++++++
+ grub-initrd-fallback.service | 14 +++++++++
+ util/grub.d/00_header.in     | 27 ++++++++++++++++++
+ util/grub.d/10_linux.in      | 68 +++++++++++++++++++++++++++++++++-----------
+ 5 files changed, 106 insertions(+), 16 deletions(-)
  create mode 100644 grub-initrd-fallback.service
 
 diff --git a/Makefile.am b/Makefile.am
-index 1f4bb9b8c..e6a220711 100644
+index 1f4bb9b..e6a2207 100644
 --- a/Makefile.am
 +++ b/Makefile.am
 @@ -473,6 +473,9 @@ ChangeLog: FORCE
@@ -33,7 +32,7 @@ index 1f4bb9b8c..e6a220711 100644
  
  syslinux_test: $(top_builddir)/config.status tests/syslinux/ubuntu10.04_grub.cfg
 diff --git a/configure.ac b/configure.ac
-index 883245553..1819188f9 100644
+index 8832455..1819188 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -305,6 +305,16 @@ AC_SUBST(grubdirname)
@@ -55,14 +54,15 @@ index 883245553..1819188f9 100644
  #
 diff --git a/grub-initrd-fallback.service b/grub-initrd-fallback.service
 new file mode 100644
-index 000000000..fb0b76e19
+index 0000000..1a0a4e5
 --- /dev/null
 +++ b/grub-initrd-fallback.service
-@@ -0,0 +1,13 @@
+@@ -0,0 +1,14 @@
 +[Unit]
 +Description=GRUB failed boot detection
 +After=local-fs.target
 +After=grub-common.service
++After=sleep.target
 +
 +[Service]
 +Type=oneshot
@@ -71,9 +71,9 @@ index 000000000..fb0b76e19
 +TimeoutSec=0
 +
 +[Install]
-+WantedBy=multi-user.target rescue.target emergency.target
++WantedBy=multi-user.target rescue.target emergency.target sleep.target
 diff --git a/util/grub.d/00_header.in b/util/grub.d/00_header.in
-index b7135b655..2642f66c5 100644
+index b7135b6..2642f66 100644
 --- a/util/grub.d/00_header.in
 +++ b/util/grub.d/00_header.in
 @@ -50,6 +50,18 @@ if [ -s \$prefix/grubenv ]; then
@@ -118,7 +118,7 @@ index b7135b655..2642f66c5 100644
      cat <<EOF
  function recordfail {
 diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
-index aa9666e5a..af1e096bd 100644
+index aa9666e..af1e096 100644
 --- a/util/grub.d/10_linux.in
 +++ b/util/grub.d/10_linux.in
 @@ -118,6 +118,10 @@ if [ "$vt_handoff" = 1 ]; then

--- a/debian/patches/ubuntu-add-initrd-less-boot-messages.patch
+++ b/debian/patches/ubuntu-add-initrd-less-boot-messages.patch
@@ -1,0 +1,66 @@
+From: Dimitri John Ledkov <xnox@ubuntu.com>
+Date: Mon, 26 Oct 2020 11:38:34 +0000
+Subject: Ubuntu: add initrd-less-boot informational messages
+
+Add additional messages when initrd-less boot is attempted or
+fails. As otherwise it is not obvious why boot seems to panic and
+reboot by default.
+---
+ grub-initrd-fallback.service |  1 +
+ util/grub.d/10_linux.in      | 10 ++++++++++
+ 2 files changed, 11 insertions(+)
+
+diff --git a/grub-initrd-fallback.service b/grub-initrd-fallback.service
+index 1a0a4e5..59d1a62 100644
+--- a/grub-initrd-fallback.service
++++ b/grub-initrd-fallback.service
+@@ -3,6 +3,7 @@ Description=GRUB failed boot detection
+ After=local-fs.target
+ After=grub-common.service
+ After=sleep.target
++ConditionPathExists=/boot/grub/grub.cfg
+ 
+ [Service]
+ Type=oneshot
+diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
+index 49e6272..47daf51 100644
+--- a/util/grub.d/10_linux.in
++++ b/util/grub.d/10_linux.in
+@@ -160,6 +160,12 @@ if [ "$vt_handoff" = 1 ]; then
+ fi
+ 
+ if [ x"$GRUB_FORCE_PARTUUID" != x ]; then
++    gettext_printf "GRUB_FORCE_PARTUUID is set, will attempt initrdless boot\n" >&2
++    cat << EOF
++#
++# GRUB_FORCE_PARTUUID is set, will attempt initrdless boot
++# Upon panic fallback to booting with initrd
++EOF
+    echo "set partuuid=${GRUB_FORCE_PARTUUID}"
+ fi
+ 
+@@ -245,6 +251,8 @@ EOF
+         linux_root_device_thisversion="PARTUUID=${GRUB_FORCE_PARTUUID}"
+     fi
+     message="$(gettext_printf "Loading initial ramdisk ...")"
++    initrdlessfail_msg="$(gettext_printf "GRUB_FORCE_PARTUUID set, initrdless boot failed. Attempting with initrd.")"
++    initrdlesstry_msg="$(gettext_printf "GRUB_FORCE_PARTUUID set, attempting initrdless boot.")"
+     initrd_path=
+     for i in ${initrd}; do
+         initrd_path="${initrd_path} ${rel_dirname}/${i}"
+@@ -256,6 +264,7 @@ EOF
+     if test -n "${initrd}" && [ x"$GRUB_FORCE_PARTUUID" != x ]; then
+         sed "s/^/$submenu_indentation/" << EOF
+ 	if [ "\${initrdfail}" = 1 ]; then
++	  echo	'$(echo "$initrdlessfail_msg" | grub_quote)'
+ 	  linux	${rel_dirname}/${basename} root=${linux_root_device_thisversion} ro ${args}
+ EOF
+         if [ x"$quiet_boot" = x0 ] || [ x"$type" != xsimple ]; then
+@@ -266,6 +275,7 @@ EOF
+         sed "s/^/$submenu_indentation/" << EOF
+ 	  initrd	$(echo $initrd_path)
+ 	else
++	  echo	'$(echo "$initrdlesstry_msg" | grub_quote)'
+ 	  linux	${rel_dirname}/${basename} root=${linux_root_device_thisversion} ro ${args} panic=-1
+ EOF
+         if [ -n "$initrd_path_only_early" ]; then

--- a/debian/patches/ubuntu-boot-from-multipath-dependent-symlink.patch
+++ b/debian/patches/ubuntu-boot-from-multipath-dependent-symlink.patch
@@ -1,4 +1,3 @@
-From 79cfb6d9c5b8f0d6dcee694c48fb59bb6321696b Mon Sep 17 00:00:00 2001
 From: Michael Hudson-Doyle <michael.hudson@canonical.com>
 Date: Tue, 6 Aug 2019 12:31:47 +1200
 Subject: UBUNTU: Boot from multipath-dependent symlink when / is multipathed.
@@ -16,7 +15,7 @@ Patch-Name: ubuntu-boot-from-multipath-dependent-symlink.patch
  1 file changed, 41 insertions(+)
 
 diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
-index bbf5d73e3..14a89ba13 100644
+index bbf5d73..14a89ba 100644
 --- a/util/grub.d/10_linux.in
 +++ b/util/grub.d/10_linux.in
 @@ -65,6 +65,47 @@ esac

--- a/debian/patches/ubuntu-dont-verify-loopback-images.patch
+++ b/debian/patches/ubuntu-dont-verify-loopback-images.patch
@@ -1,4 +1,3 @@
-From dd1c8d04888d4d5a36e076be39b871b669ebd169 Mon Sep 17 00:00:00 2001
 From: Chris Coulson <chris.coulson@canonical.com>
 Date: Mon, 1 Jun 2020 14:03:37 +0100
 Subject: UBUNTU: disk/loopback: Don't verify loopback images
@@ -22,7 +21,7 @@ Patch-Name: ubuntu-dont-verify-loopback-images.patch
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/grub-core/disk/loopback.c b/grub-core/disk/loopback.c
-index ccb4b167c..210201d22 100644
+index ccb4b16..210201d 100644
 --- a/grub-core/disk/loopback.c
 +++ b/grub-core/disk/loopback.c
 @@ -86,7 +86,8 @@ grub_cmd_loopback (grub_extcmd_context_t ctxt, int argc, char **args)

--- a/debian/patches/ubuntu-efi-allow-loopmount-chainload.patch
+++ b/debian/patches/ubuntu-efi-allow-loopmount-chainload.patch
@@ -1,4 +1,3 @@
-From 5e83ad86707acfad2d8bdcf44c3b2202251b2252 Mon Sep 17 00:00:00 2001
 From: Dimitri John Ledkov <xnox@ubuntu.com>
 Date: Wed, 27 Nov 2019 23:12:35 +0000
 Subject: UBUNTU: Allow chainloading EFI apps from loop mounts.
@@ -15,7 +14,7 @@ Patch-Name: ubuntu-efi-allow-loopmount-chainload.patch
  create mode 100644 include/grub/loopback.h
 
 diff --git a/grub-core/disk/loopback.c b/grub-core/disk/loopback.c
-index cdf9123fa..ccb4b167c 100644
+index cdf9123..ccb4b16 100644
 --- a/grub-core/disk/loopback.c
 +++ b/grub-core/disk/loopback.c
 @@ -21,20 +21,13 @@
@@ -41,7 +40,7 @@ index cdf9123fa..ccb4b167c 100644
  static unsigned long last_id = 0;
  
 diff --git a/grub-core/loader/efi/chainloader.c b/grub-core/loader/efi/chainloader.c
-index ec80f415b..04e815c05 100644
+index ec80f41..04e815c 100644
 --- a/grub-core/loader/efi/chainloader.c
 +++ b/grub-core/loader/efi/chainloader.c
 @@ -24,6 +24,7 @@
@@ -91,7 +90,7 @@ index ec80f415b..04e815c05 100644
  
 diff --git a/include/grub/loopback.h b/include/grub/loopback.h
 new file mode 100644
-index 000000000..3b9a9e32e
+index 0000000..3b9a9e3
 --- /dev/null
 +++ b/include/grub/loopback.h
 @@ -0,0 +1,30 @@

--- a/debian/patches/ubuntu-efi-console-set-text-mode-as-needed.patch
+++ b/debian/patches/ubuntu-efi-console-set-text-mode-as-needed.patch
@@ -1,4 +1,3 @@
-From a097dd966d2a0073a3f2f30f868fae351b74fda4 Mon Sep 17 00:00:00 2001
 From: Hans de Goede <hdegoede@redhat.com>
 Date: Tue, 6 Mar 2018 17:11:15 +0100
 Subject: UBUNTU: EFI: Do not set text-mode until we actually need it
@@ -11,11 +10,11 @@ Signed-off-by: Hans de Goede <hdegoede@redhat.com>
 Last-Update: 2019-03-06
 Patch-Name: ubuntu-efi-console-set-text-mode-as-needed.patch
 ---
- grub-core/term/efi/console.c | 68 ++++++++++++++++++++++++------------
+ grub-core/term/efi/console.c | 68 +++++++++++++++++++++++++++++---------------
  1 file changed, 45 insertions(+), 23 deletions(-)
 
 diff --git a/grub-core/term/efi/console.c b/grub-core/term/efi/console.c
-index 4840cc59d..b61da7d0d 100644
+index 4840cc5..b61da7d 100644
 --- a/grub-core/term/efi/console.c
 +++ b/grub-core/term/efi/console.c
 @@ -24,6 +24,11 @@

--- a/debian/patches/ubuntu-fix-lzma-decompressor-objcopy.patch
+++ b/debian/patches/ubuntu-fix-lzma-decompressor-objcopy.patch
@@ -1,4 +1,3 @@
-From 3bfa5526e2d5b05f75be0af30b099f95139d99f3 Mon Sep 17 00:00:00 2001
 From: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
 Date: Wed, 3 Jul 2019 15:21:16 -0400
 Subject: UBUNTU: Have the lzma decompressor image only contain the .text
@@ -16,7 +15,7 @@ Signed-off-by: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
-index 1731c53f0..33e75021d 100644
+index 1731c53..33e7502 100644
 --- a/grub-core/Makefile.core.def
 +++ b/grub-core/Makefile.core.def
 @@ -547,7 +547,7 @@ image = {

--- a/debian/patches/ubuntu-flavour-order.patch
+++ b/debian/patches/ubuntu-flavour-order.patch
@@ -1,4 +1,3 @@
-From 2310fddfe741bf77f8721675a679478d0b6a5613 Mon Sep 17 00:00:00 2001
 From: Julian Andres Klode <julian.klode@canonical.com>
 Date: Tue, 9 Jun 2020 11:50:23 +0200
 Subject: UBUNTU: Add GRUB_FLAVOUR_ORDER configuration item
@@ -20,7 +19,7 @@ Patch-Name: ubuntu-flavour-order.patch
  2 files changed, 17 insertions(+), 1 deletion(-)
 
 diff --git a/util/grub-mkconfig.in b/util/grub-mkconfig.in
-index 72f1e25a0..6c8988fd6 100644
+index 72f1e25..6c8988f 100644
 --- a/util/grub-mkconfig.in
 +++ b/util/grub-mkconfig.in
 @@ -260,7 +260,8 @@ export GRUB_DEFAULT \
@@ -34,7 +33,7 @@ index 72f1e25a0..6c8988fd6 100644
  if test "x${grub_cfg}" != "x"; then
    rm -f "${grub_cfg}.new"
 diff --git a/util/grub-mkconfig_lib.in b/util/grub-mkconfig_lib.in
-index fe6319abe..7e2d1bc21 100644
+index fe6319a..7e2d1bc 100644
 --- a/util/grub-mkconfig_lib.in
 +++ b/util/grub-mkconfig_lib.in
 @@ -270,6 +270,21 @@ version_test_gt ()

--- a/debian/patches/ubuntu-grub-install-extra-removable.patch
+++ b/debian/patches/ubuntu-grub-install-extra-removable.patch
@@ -1,4 +1,3 @@
-From 42b10df3ba7aff3f58b32cd43a0075a677fa8143 Mon Sep 17 00:00:00 2001
 From: Steve McIntyre <93sam@debian.org>
 Date: Wed, 3 Dec 2014 01:25:12 +0000
 Subject: UBUNTU: Add support for forcing EFI installation to the removable
@@ -19,11 +18,11 @@ Last-Update: 2014-12-20
 
 Patch-Name: ubuntu-grub-install-extra-removable.patch
 ---
- util/grub-install.c | 135 +++++++++++++++++++++++++++++++++++++++++++-
+ util/grub-install.c | 135 +++++++++++++++++++++++++++++++++++++++++++++++++++-
  1 file changed, 133 insertions(+), 2 deletions(-)
 
 diff --git a/util/grub-install.c b/util/grub-install.c
-index 64c292383..030464645 100644
+index 64c2923..0304646 100644
 --- a/util/grub-install.c
 +++ b/util/grub-install.c
 @@ -56,6 +56,7 @@

--- a/debian/patches/ubuntu-install-signed.patch
+++ b/debian/patches/ubuntu-install-signed.patch
@@ -1,9 +1,8 @@
-From e1cc8a0711a700332db770c6e741d60ca2f9cce8 Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@ubuntu.com>
 Date: Mon, 13 Jan 2014 12:13:22 +0000
 Subject: UBUNTU: Install signed images if UEFI Secure Boot is enabled
 MIME-Version: 1.0
-Content-Type: text/plain; charset=UTF-8
+Content-Type: text/plain; charset="utf-8"
 Content-Transfer-Encoding: 8bit
 
 Author: Stéphane Graber <stgraber@ubuntu.com>
@@ -15,11 +14,11 @@ Last-Update: 2016-11-01
 
 Patch-Name: ubuntu-install-signed.patch
 ---
- util/grub-install.c | 215 ++++++++++++++++++++++++++++++++------------
+ util/grub-install.c | 215 ++++++++++++++++++++++++++++++++++++++--------------
  1 file changed, 156 insertions(+), 59 deletions(-)
 
 diff --git a/util/grub-install.c b/util/grub-install.c
-index 3b4606eef..e1e40cf2b 100644
+index 3b4606e..e1e40cf 100644
 --- a/util/grub-install.c
 +++ b/util/grub-install.c
 @@ -80,6 +80,7 @@ static char *label_color;

--- a/debian/patches/ubuntu-linuxefi-arm64-set-base-addr.patch
+++ b/debian/patches/ubuntu-linuxefi-arm64-set-base-addr.patch
@@ -1,7 +1,7 @@
-From 619882cb80281fd0c1df10be674bb04929163cc1 Mon Sep 17 00:00:00 2001
 From: Javier Martinez Canillas <javierm@redhat.com>
 Date: Thu, 23 Apr 2020 15:06:46 +0200
-Subject: efi: Set image base address before jumping to the PE/COFF entry point
+Subject: efi: Set image base address before jumping to the PE/COFF entry
+ point
 
 Upstream GRUB uses the EFI LoadImage() and StartImage() to boot the Linux
 kernel. But our custom EFI loader that supports Secure Boot instead uses
@@ -34,7 +34,7 @@ Patch-Name: ubuntu-linuxefi-arm64-set-base-addr.patch
  1 file changed, 15 insertions(+)
 
 diff --git a/grub-core/loader/efi/linux.c b/grub-core/loader/efi/linux.c
-index f6d30bcf7..a09479cd6 100644
+index f6d30bc..a09479c 100644
 --- a/grub-core/loader/efi/linux.c
 +++ b/grub-core/loader/efi/linux.c
 @@ -72,6 +72,7 @@ grub_err_t

--- a/debian/patches/ubuntu-linuxefi-arm64.patch
+++ b/debian/patches/ubuntu-linuxefi-arm64.patch
@@ -1,4 +1,3 @@
-From 9da5c0e0e228b8ce4f53d19ef64f0414688648fc Mon Sep 17 00:00:00 2001
 From: Julian Andres Klode <julian.klode@canonical.com>
 Date: Fri, 11 Sep 2020 11:28:08 +0200
 Subject: Cherry-pick back parts of "Load arm with SB enabled."
@@ -13,11 +12,11 @@ Bug-Ubuntu: https://bugs.launchpad.net/bugs/1862279
 Origin: vendor, https://github.com/rhboot/grub2/commit/2786ab864cf00c15123320671f653e9a36ba12b4
 Patch-Name: ubuntu-linuxefi-arm64.patch
 ---
- grub-core/loader/arm64/linux.c | 106 +++++++++++++++++----------------
+ grub-core/loader/arm64/linux.c | 106 ++++++++++++++++++++++-------------------
  1 file changed, 56 insertions(+), 50 deletions(-)
 
 diff --git a/grub-core/loader/arm64/linux.c b/grub-core/loader/arm64/linux.c
-index 3f5496fc5..130e9c09b 100644
+index 3f5496f..130e9c0 100644
 --- a/grub-core/loader/arm64/linux.c
 +++ b/grub-core/loader/arm64/linux.c
 @@ -43,6 +43,8 @@ static int loaded;

--- a/debian/patches/ubuntu-linuxefi.patch
+++ b/debian/patches/ubuntu-linuxefi.patch
@@ -1,4 +1,3 @@
-From 5d037853169fac31b3c0cfe7a6b6c4eb267879d3 Mon Sep 17 00:00:00 2001
 From: Matthew Garrett <mjg@redhat.com>
 Date: Wed, 27 Feb 2019 12:20:48 -0500
 Subject: UBUNTU: Add support for linuxefi
@@ -322,25 +321,25 @@ Last-Update: 2018-12-07
  grub-core/commands/memrw.c             |   7 +
  grub-core/kern/arm/coreboot/coreboot.S |   6 +
  grub-core/kern/dl.c                    |   1 +
- grub-core/kern/efi/efi.c               |  28 -
- grub-core/kern/efi/mm.c                |  32 +
- grub-core/kern/efi/sb.c                |  66 ++
+ grub-core/kern/efi/efi.c               |  28 --
+ grub-core/kern/efi/mm.c                |  32 ++
+ grub-core/kern/efi/sb.c                |  66 +++
  grub-core/loader/arm64/linux.c         |  16 +
  grub-core/loader/efi/appleloader.c     |   7 +
- grub-core/loader/efi/chainloader.c     | 817 +++++++++++++++++++++++--
+ grub-core/loader/efi/chainloader.c     | 817 ++++++++++++++++++++++++++++++---
  grub-core/loader/efi/fdt.c             |   1 +
- grub-core/loader/efi/linux.c           |  86 +++
+ grub-core/loader/efi/linux.c           |  86 ++++
  grub-core/loader/i386/bsd.c            |   7 +
- grub-core/loader/i386/efi/linux.c      | 379 ++++++++++++
- grub-core/loader/i386/linux.c          |  78 ++-
+ grub-core/loader/i386/efi/linux.c      | 379 +++++++++++++++
+ grub-core/loader/i386/linux.c          |  78 +++-
  grub-core/loader/i386/pc/linux.c       |  40 +-
  grub-core/loader/multiboot.c           |   7 +
  grub-core/loader/xnu.c                 |   7 +
  include/grub/arm64/linux.h             |   2 +
  include/grub/efi/efi.h                 |   4 +-
- include/grub/efi/linux.h               |  31 +
- include/grub/efi/pe32.h                |  52 +-
- include/grub/efi/sb.h                  |  29 +
+ include/grub/efi/linux.h               |  31 ++
+ include/grub/efi/pe32.h                |  52 ++-
+ include/grub/efi/sb.h                  |  29 ++
  include/grub/i386/linux.h              |   7 +-
  include/grub/ia64/linux.h              |   0
  include/grub/mips/linux.h              |   0
@@ -358,7 +357,7 @@ Last-Update: 2018-12-07
  create mode 100644 include/grub/sparc64/linux.h
 
 diff --git a/grub-core/Makefile.am b/grub-core/Makefile.am
-index 3ea8e7ff4..c6ba5b2d7 100644
+index 3ea8e7f..c6ba5b2 100644
 --- a/grub-core/Makefile.am
 +++ b/grub-core/Makefile.am
 @@ -71,6 +71,7 @@ KERNEL_HEADER_FILES += $(top_srcdir)/include/grub/command.h
@@ -370,7 +369,7 @@ index 3ea8e7ff4..c6ba5b2d7 100644
  KERNEL_HEADER_FILES += $(top_srcdir)/include/grub/env_private.h
  KERNEL_HEADER_FILES += $(top_srcdir)/include/grub/err.h
 diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
-index aadb4cdff..1731c53f0 100644
+index aadb4cd..1731c53 100644
 --- a/grub-core/Makefile.core.def
 +++ b/grub-core/Makefile.core.def
 @@ -207,6 +207,7 @@ kernel = {
@@ -428,7 +427,7 @@ index aadb4cdff..1731c53f0 100644
    enable = i386_coreboot;
    enable = efi;
 diff --git a/grub-core/commands/iorw.c b/grub-core/commands/iorw.c
-index a0c164e54..41a7f3f04 100644
+index a0c164e..41a7f3f 100644
 --- a/grub-core/commands/iorw.c
 +++ b/grub-core/commands/iorw.c
 @@ -23,6 +23,7 @@
@@ -460,7 +459,7 @@ index a0c164e54..41a7f3f04 100644
    grub_unregister_extcmd (cmd_read_word);
    grub_unregister_extcmd (cmd_read_dword);
 diff --git a/grub-core/commands/memrw.c b/grub-core/commands/memrw.c
-index 98769eadb..088cbe9e2 100644
+index 98769ea..088cbe9 100644
 --- a/grub-core/commands/memrw.c
 +++ b/grub-core/commands/memrw.c
 @@ -22,6 +22,7 @@
@@ -492,7 +491,7 @@ index 98769eadb..088cbe9e2 100644
    grub_unregister_extcmd (cmd_read_word);
    grub_unregister_extcmd (cmd_read_dword);
 diff --git a/grub-core/kern/arm/coreboot/coreboot.S b/grub-core/kern/arm/coreboot/coreboot.S
-index a1104526c..70998c066 100644
+index a110452..70998c0 100644
 --- a/grub-core/kern/arm/coreboot/coreboot.S
 +++ b/grub-core/kern/arm/coreboot/coreboot.S
 @@ -42,3 +42,9 @@ FUNCTION(grub_armv7_get_timer_frequency)
@@ -506,7 +505,7 @@ index a1104526c..70998c066 100644
 +				  void *kernel_param);
 +
 diff --git a/grub-core/kern/dl.c b/grub-core/kern/dl.c
-index 074dfc3c6..d665c10fc 100644
+index 074dfc3..d665c10 100644
 --- a/grub-core/kern/dl.c
 +++ b/grub-core/kern/dl.c
 @@ -32,6 +32,7 @@
@@ -518,7 +517,7 @@ index 074dfc3c6..d665c10fc 100644
  /* Platforms where modules are in a readonly area of memory.  */
  #if defined(GRUB_MACHINE_QEMU)
 diff --git a/grub-core/kern/efi/efi.c b/grub-core/kern/efi/efi.c
-index 96204e39b..6e1ceb905 100644
+index 96204e3..6e1ceb9 100644
 --- a/grub-core/kern/efi/efi.c
 +++ b/grub-core/kern/efi/efi.c
 @@ -273,34 +273,6 @@ grub_efi_get_variable (const char *var, const grub_efi_guid_t *guid,
@@ -557,7 +556,7 @@ index 96204e39b..6e1ceb905 100644
  
  /* Search the mods section from the PE32/PE32+ image. This code uses
 diff --git a/grub-core/kern/efi/mm.c b/grub-core/kern/efi/mm.c
-index b02fab1b1..a9e37108c 100644
+index b02fab1..a9e3710 100644
 --- a/grub-core/kern/efi/mm.c
 +++ b/grub-core/kern/efi/mm.c
 @@ -113,6 +113,38 @@ grub_efi_drop_alloc (grub_efi_physical_address_t address,
@@ -601,7 +600,7 @@ index b02fab1b1..a9e37108c 100644
  grub_efi_allocate_pages_real (grub_efi_physical_address_t address,
 diff --git a/grub-core/kern/efi/sb.c b/grub-core/kern/efi/sb.c
 new file mode 100644
-index 000000000..c14f401d7
+index 0000000..c14f401
 --- /dev/null
 +++ b/grub-core/kern/efi/sb.c
 @@ -0,0 +1,66 @@
@@ -672,7 +671,7 @@ index 000000000..c14f401d7
 +#endif
 +}
 diff --git a/grub-core/loader/arm64/linux.c b/grub-core/loader/arm64/linux.c
-index ef3e9f944..1a5296a60 100644
+index ef3e9f9..1a5296a 100644
 --- a/grub-core/loader/arm64/linux.c
 +++ b/grub-core/loader/arm64/linux.c
 @@ -27,6 +27,7 @@
@@ -720,7 +719,7 @@ index ef3e9f944..1a5296a60 100644
    linux_args = grub_malloc (cmdline_size);
    if (!linux_args)
 diff --git a/grub-core/loader/efi/appleloader.c b/grub-core/loader/efi/appleloader.c
-index 74888c463..69c2a10d3 100644
+index 74888c4..69c2a10 100644
 --- a/grub-core/loader/efi/appleloader.c
 +++ b/grub-core/loader/efi/appleloader.c
 @@ -24,6 +24,7 @@
@@ -751,7 +750,7 @@ index 74888c463..69c2a10d3 100644
    grub_unregister_command (cmd);
  }
 diff --git a/grub-core/loader/efi/chainloader.c b/grub-core/loader/efi/chainloader.c
-index cd92ea3f2..ec80f415b 100644
+index cd92ea3..ec80f41 100644
 --- a/grub-core/loader/efi/chainloader.c
 +++ b/grub-core/loader/efi/chainloader.c
 @@ -32,6 +32,9 @@
@@ -1701,7 +1700,7 @@ index cd92ea3f2..ec80f415b 100644
  
    return grub_errno;
 diff --git a/grub-core/loader/efi/fdt.c b/grub-core/loader/efi/fdt.c
-index f0c2d91be..5360e6c1f 100644
+index f0c2d91..5360e6c 100644
 --- a/grub-core/loader/efi/fdt.c
 +++ b/grub-core/loader/efi/fdt.c
 @@ -25,6 +25,7 @@
@@ -1714,7 +1713,7 @@ index f0c2d91be..5360e6c1f 100644
  static void *fdt;
 diff --git a/grub-core/loader/efi/linux.c b/grub-core/loader/efi/linux.c
 new file mode 100644
-index 000000000..e372b26a1
+index 0000000..e372b26
 --- /dev/null
 +++ b/grub-core/loader/efi/linux.c
 @@ -0,0 +1,86 @@
@@ -1805,7 +1804,7 @@ index 000000000..e372b26a1
 +  return GRUB_ERR_BUG;
 +}
 diff --git a/grub-core/loader/i386/bsd.c b/grub-core/loader/i386/bsd.c
-index 3730ed382..5b9b92d6b 100644
+index 3730ed3..5b9b92d 100644
 --- a/grub-core/loader/i386/bsd.c
 +++ b/grub-core/loader/i386/bsd.c
 @@ -39,6 +39,7 @@
@@ -1838,7 +1837,7 @@ index 3730ed382..5b9b92d6b 100644
    grub_unregister_extcmd (cmd_netbsd);
 diff --git a/grub-core/loader/i386/efi/linux.c b/grub-core/loader/i386/efi/linux.c
 new file mode 100644
-index 000000000..6b6aef87f
+index 0000000..6b6aef8
 --- /dev/null
 +++ b/grub-core/loader/i386/efi/linux.c
 @@ -0,0 +1,379 @@
@@ -2222,7 +2221,7 @@ index 000000000..6b6aef87f
 +  grub_unregister_command (cmd_initrd);
 +}
 diff --git a/grub-core/loader/i386/linux.c b/grub-core/loader/i386/linux.c
-index d0501e229..4328bcbdb 100644
+index d0501e2..4328bcb 100644
 --- a/grub-core/loader/i386/linux.c
 +++ b/grub-core/loader/i386/linux.c
 @@ -45,6 +45,7 @@ GRUB_MOD_LICENSE ("GPLv3+");
@@ -2390,7 +2389,7 @@ index d0501e229..4328bcbdb 100644
      {
        grub_error (GRUB_ERR_BAD_ARGUMENT, N_("filename expected"));
 diff --git a/grub-core/loader/i386/pc/linux.c b/grub-core/loader/i386/pc/linux.c
-index 47ea2945e..3866f048b 100644
+index 47ea294..3866f04 100644
 --- a/grub-core/loader/i386/pc/linux.c
 +++ b/grub-core/loader/i386/pc/linux.c
 @@ -35,6 +35,7 @@
@@ -2503,7 +2502,7 @@ index 47ea2945e..3866f048b 100644
    grub_unregister_command (cmd_initrd);
  }
 diff --git a/grub-core/loader/multiboot.c b/grub-core/loader/multiboot.c
-index 4a98d7082..3e6ad166d 100644
+index 4a98d70..3e6ad16 100644
 --- a/grub-core/loader/multiboot.c
 +++ b/grub-core/loader/multiboot.c
 @@ -50,6 +50,7 @@
@@ -2535,7 +2534,7 @@ index 4a98d7082..3e6ad166d 100644
    grub_unregister_command (cmd_module);
  }
 diff --git a/grub-core/loader/xnu.c b/grub-core/loader/xnu.c
-index 7f74d1d6f..e0f47e72b 100644
+index 7f74d1d..e0f47e7 100644
 --- a/grub-core/loader/xnu.c
 +++ b/grub-core/loader/xnu.c
 @@ -34,6 +34,7 @@
@@ -2567,7 +2566,7 @@ index 7f74d1d6f..e0f47e72b 100644
    grub_unregister_command (cmd_resume);
  #endif
 diff --git a/include/grub/arm64/linux.h b/include/grub/arm64/linux.h
-index 4269adc6d..cc8174ccd 100644
+index 4269adc..cc8174c 100644
 --- a/include/grub/arm64/linux.h
 +++ b/include/grub/arm64/linux.h
 @@ -20,6 +20,8 @@
@@ -2580,7 +2579,7 @@ index 4269adc6d..cc8174ccd 100644
  /* From linux/Documentation/arm64/booting.txt */
  struct linux_arm64_kernel_header
 diff --git a/include/grub/efi/efi.h b/include/grub/efi/efi.h
-index a237952b3..5b6387581 100644
+index a237952..5b63875 100644
 --- a/include/grub/efi/efi.h
 +++ b/include/grub/efi/efi.h
 @@ -47,6 +47,9 @@ EXPORT_FUNC(grub_efi_allocate_fixed) (grub_efi_physical_address_t address,
@@ -2603,7 +2602,7 @@ index a237952b3..5b6387581 100644
  					     const grub_efi_device_path_t *dp2);
 diff --git a/include/grub/efi/linux.h b/include/grub/efi/linux.h
 new file mode 100644
-index 000000000..0033d9305
+index 0000000..0033d93
 --- /dev/null
 +++ b/include/grub/efi/linux.h
 @@ -0,0 +1,31 @@
@@ -2639,7 +2638,7 @@ index 000000000..0033d9305
 +
 +#endif /* ! GRUB_EFI_LINUX_HEADER */
 diff --git a/include/grub/efi/pe32.h b/include/grub/efi/pe32.h
-index 0ed8781f0..a43adf274 100644
+index 0ed8781..a43adf2 100644
 --- a/include/grub/efi/pe32.h
 +++ b/include/grub/efi/pe32.h
 @@ -223,7 +223,11 @@ struct grub_pe64_optional_header
@@ -2730,7 +2729,7 @@ index 0ed8781f0..a43adf274 100644
    grub_uint32_t page_rva;
 diff --git a/include/grub/efi/sb.h b/include/grub/efi/sb.h
 new file mode 100644
-index 000000000..9629fbb0f
+index 0000000..9629fbb
 --- /dev/null
 +++ b/include/grub/efi/sb.h
 @@ -0,0 +1,29 @@
@@ -2764,7 +2763,7 @@ index 000000000..9629fbb0f
 +
 +#endif /* ! GRUB_EFI_SB_HEADER */
 diff --git a/include/grub/i386/linux.h b/include/grub/i386/linux.h
-index ce30e7fb0..a093679cb 100644
+index ce30e7f..a093679 100644
 --- a/include/grub/i386/linux.h
 +++ b/include/grub/i386/linux.h
 @@ -136,7 +136,12 @@ struct linux_i386_kernel_header
@@ -2783,13 +2782,13 @@ index ce30e7fb0..a093679cb 100644
    grub_uint64_t hardware_subarch_data;
 diff --git a/include/grub/ia64/linux.h b/include/grub/ia64/linux.h
 new file mode 100644
-index 000000000..e69de29bb
+index 0000000..e69de29
 diff --git a/include/grub/mips/linux.h b/include/grub/mips/linux.h
 new file mode 100644
-index 000000000..e69de29bb
+index 0000000..e69de29
 diff --git a/include/grub/powerpc/linux.h b/include/grub/powerpc/linux.h
 new file mode 100644
-index 000000000..e69de29bb
+index 0000000..e69de29
 diff --git a/include/grub/sparc64/linux.h b/include/grub/sparc64/linux.h
 new file mode 100644
-index 000000000..e69de29bb
+index 0000000..e69de29

--- a/debian/patches/ubuntu-mkconfig-leave-breadcrumbs.patch
+++ b/debian/patches/ubuntu-mkconfig-leave-breadcrumbs.patch
@@ -1,4 +1,3 @@
-From 6bf5c1a419c2831a37abed1f4595db3f4dee9057 Mon Sep 17 00:00:00 2001
 From: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
 Date: Fri, 14 Dec 2018 13:46:14 -0500
 Subject: UBUNTU: grub-mkconfig: leave a trace of what files were sourced to
@@ -11,7 +10,7 @@ Signed-off-by: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
  1 file changed, 2 insertions(+)
 
 diff --git a/util/grub-mkconfig.in b/util/grub-mkconfig.in
-index 29bdad0c1..72f1e25a0 100644
+index 29bdad0..72f1e25 100644
 --- a/util/grub-mkconfig.in
 +++ b/util/grub-mkconfig.in
 @@ -162,10 +162,12 @@ if [ "x${GRUB_EARLY_INITRD_LINUX_STOCK}" = "x" ]; then

--- a/debian/patches/ubuntu-recovery-dis_ucode_ldr.patch
+++ b/debian/patches/ubuntu-recovery-dis_ucode_ldr.patch
@@ -1,4 +1,3 @@
-From eadf7d3423b13556336ee7c6d2ed651e4a376f0e Mon Sep 17 00:00:00 2001
 From: Julian Andres Klode <julian.klode@canonical.com>
 Date: Fri, 19 Jun 2020 12:57:19 +0200
 Subject: Pass dis_ucode_ldr to kernel for recovery mode
@@ -19,7 +18,7 @@ Patch-Name: ubuntu-recovery-dis_ucode_ldr.patch
  2 files changed, 19 insertions(+), 9 deletions(-)
 
 diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
-index 14a89ba13..49e627228 100644
+index 14a89ba..49e6272 100644
 --- a/util/grub.d/10_linux.in
 +++ b/util/grub.d/10_linux.in
 @@ -334,6 +334,10 @@ case "$machine" in
@@ -34,7 +33,7 @@ index 14a89ba13..49e627228 100644
  prepare_root_cache=
  boot_device_id=
 diff --git a/util/grub.d/10_linux_zfs.in b/util/grub.d/10_linux_zfs.in
-index 712d83280..d9b79e29a 100755
+index 712d832..d9b79e2 100755
 --- a/util/grub.d/10_linux_zfs.in
 +++ b/util/grub.d/10_linux_zfs.in
 @@ -41,6 +41,16 @@ imported_pools=""

--- a/debian/patches/ubuntu-resilient-boot-boot-order.patch
+++ b/debian/patches/ubuntu-resilient-boot-boot-order.patch
@@ -1,4 +1,3 @@
-From 92f0f99e1e0d9c38a427009831aa8cca278850ec Mon Sep 17 00:00:00 2001
 From: Julian Andres Klode <julian.klode@canonical.com>
 Date: Wed, 8 Apr 2020 11:05:25 +0200
 Subject: UBUNTU: efivar: Correctly handle boot order of multiple ESPs
@@ -22,15 +21,15 @@ primary ESP - that is, mounted to /boot/efi - or not.
 Patch-Name: ubuntu-resilient-boot-boot-order.patch
 ---
  grub-core/osdep/basic/no_platform.c |  2 +-
- grub-core/osdep/unix/efivar.c       | 48 +++++++++++++++++++++++++----
- grub-core/osdep/unix/platform.c     |  6 ++--
+ grub-core/osdep/unix/efivar.c       | 48 ++++++++++++++++++++++++++++++++-----
+ grub-core/osdep/unix/platform.c     |  6 ++---
  grub-core/osdep/windows/platform.c  |  2 +-
- include/grub/util/install.h         | 17 +++++-----
- util/grub-install.c                 |  8 ++---
+ include/grub/util/install.h         | 17 +++++++------
+ util/grub-install.c                 |  8 +++----
  6 files changed, 59 insertions(+), 24 deletions(-)
 
 diff --git a/grub-core/osdep/basic/no_platform.c b/grub-core/osdep/basic/no_platform.c
-index d76c34c14..152a32873 100644
+index d76c34c..152a328 100644
 --- a/grub-core/osdep/basic/no_platform.c
 +++ b/grub-core/osdep/basic/no_platform.c
 @@ -31,7 +31,7 @@ grub_install_register_ieee1275 (int is_prep, const char *install_device,
@@ -43,7 +42,7 @@ index d76c34c14..152a32873 100644
  			   const char *efi_distributor)
  {
 diff --git a/grub-core/osdep/unix/efivar.c b/grub-core/osdep/unix/efivar.c
-index 41d39c448..d34df0f70 100644
+index 41d39c4..d34df0f 100644
 --- a/grub-core/osdep/unix/efivar.c
 +++ b/grub-core/osdep/unix/efivar.c
 @@ -266,9 +266,10 @@ remove_from_boot_order (struct efi_variable *order, uint16_t num)
@@ -142,7 +141,7 @@ index 41d39c448..d34df0f70 100644
    grub_util_info ("setting EFI variable BootOrder");
    rc = set_efi_variable ("BootOrder", order);
 diff --git a/grub-core/osdep/unix/platform.c b/grub-core/osdep/unix/platform.c
-index b561174ea..a5267db68 100644
+index b561174..a5267db 100644
 --- a/grub-core/osdep/unix/platform.c
 +++ b/grub-core/osdep/unix/platform.c
 @@ -76,13 +76,13 @@ get_ofpathname (const char *dev)
@@ -163,7 +162,7 @@ index b561174ea..a5267db68 100644
    grub_util_error ("%s",
  		   _("GRUB was not built with efivar support; "
 diff --git a/grub-core/osdep/windows/platform.c b/grub-core/osdep/windows/platform.c
-index e19a3d9a8..a3f738fb9 100644
+index e19a3d9..a3f738f 100644
 --- a/grub-core/osdep/windows/platform.c
 +++ b/grub-core/osdep/windows/platform.c
 @@ -208,7 +208,7 @@ set_efi_variable_bootn (grub_uint16_t n, void *in, grub_size_t len)
@@ -176,7 +175,7 @@ index e19a3d9a8..a3f738fb9 100644
  			   const char *efi_distributor)
  {
 diff --git a/include/grub/util/install.h b/include/grub/util/install.h
-index a521f1663..b2ed88e38 100644
+index a521f16..b2ed88e 100644
 --- a/include/grub/util/install.h
 +++ b/include/grub/util/install.h
 @@ -219,15 +219,14 @@ grub_install_get_default_x86_platform (void);
@@ -204,7 +203,7 @@ index a521f1663..b2ed88e38 100644
  void
  grub_install_register_ieee1275 (int is_prep, const char *install_device,
 diff --git a/util/grub-install.c b/util/grub-install.c
-index bf8eb65b3..f408b1986 100644
+index bf8eb65..f408b19 100644
 --- a/util/grub-install.c
 +++ b/util/grub-install.c
 @@ -2083,9 +2083,9 @@ main (int argc, char *argv[])

--- a/debian/patches/ubuntu-resilient-boot-ignore-alternative-esps.patch
+++ b/debian/patches/ubuntu-resilient-boot-ignore-alternative-esps.patch
@@ -1,4 +1,3 @@
-From 68cb301d0ca0b01bfea30e806d8cfc4a9960af24 Mon Sep 17 00:00:00 2001
 From: Julian Andres Klode <julian.klode@canonical.com>
 Date: Fri, 3 Apr 2020 13:43:49 +0200
 Subject: UBUNTU: efivar: Ignore alternative ESPs
@@ -9,11 +8,11 @@ then we ignore those when looking for entries to change/remove.
 
 Patch-Name: ubuntu-resilient-boot-ignore-alternative-esps.patch
 ---
- grub-core/osdep/unix/efivar.c | 130 ++++++++++++++++++++++++++++++++--
+ grub-core/osdep/unix/efivar.c | 130 ++++++++++++++++++++++++++++++++++++++++--
  1 file changed, 125 insertions(+), 5 deletions(-)
 
 diff --git a/grub-core/osdep/unix/efivar.c b/grub-core/osdep/unix/efivar.c
-index 4a58328b4..41d39c448 100644
+index 4a58328..41d39c4 100644
 --- a/grub-core/osdep/unix/efivar.c
 +++ b/grub-core/osdep/unix/efivar.c
 @@ -37,9 +37,11 @@

--- a/debian/patches/ubuntu-shorter-version-info.patch
+++ b/debian/patches/ubuntu-shorter-version-info.patch
@@ -1,8 +1,7 @@
-From 05aa4e9758b7afb0866081795e1d7c139861ac97 Mon Sep 17 00:00:00 2001
 From: Julian Andres Klode <julian.klode@canonical.com>
 Date: Thu, 8 Feb 2018 10:48:37 +0100
-Subject: UBUNTU: Show only upstream version, hide rest in package_version
- variable
+Subject: UBUNTU: Show only upstream version,
+ hide rest in package_version variable
 
 The complete package version can get a bit long, so only show the
 upstream version in the menu and on the top of the console, and
@@ -17,7 +16,7 @@ Patch-Name: ubuntu-shorter-version-info.patch
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/grub-core/normal/main.c b/grub-core/normal/main.c
-index 0aa389fa1..d25a8212c 100644
+index 0aa389f..d25a821 100644
 --- a/grub-core/normal/main.c
 +++ b/grub-core/normal/main.c
 @@ -208,7 +208,7 @@ grub_normal_init_page (struct grub_term_output *term,

--- a/debian/patches/ubuntu-skip-disk-by-id-lvm-pvm-uuid-entries.patch
+++ b/debian/patches/ubuntu-skip-disk-by-id-lvm-pvm-uuid-entries.patch
@@ -1,4 +1,3 @@
-From c9cd95998c212c1211531ae9f471b613f79bb817 Mon Sep 17 00:00:00 2001
 From: Rafael David Tinoco <rafaeldtinoco@ubuntu.com>
 Date: Mon, 7 Oct 2019 22:53:32 -0300
 Subject: Skip /dev/disk/by-id/lvm-pvm-uuid entries from device iteration
@@ -44,7 +43,7 @@ Patch-Name: ubuntu-skip-disk-by-id-lvm-pvm-uuid-entries.patch
  1 file changed, 3 insertions(+)
 
 diff --git a/util/deviceiter.c b/util/deviceiter.c
-index dddc50da7..ec9a6d0ab 100644
+index dddc50d..ec9a6d0 100644
 --- a/util/deviceiter.c
 +++ b/util/deviceiter.c
 @@ -589,6 +589,9 @@ grub_util_iterate_devices (int (*hook) (const char *, int, void *), void *hook_d

--- a/debian/patches/ubuntu-speed-zsys-history.patch
+++ b/debian/patches/ubuntu-speed-zsys-history.patch
@@ -1,4 +1,3 @@
-From 77b88d295201eaa6ad383baee8011321394579a4 Mon Sep 17 00:00:00 2001
 From: Didier Roche <didrocks@ubuntu.com>
 Date: Mon, 13 Apr 2020 15:12:21 +0200
 Subject: UBUNTU: Improve performance in bootmenu for zsys
@@ -13,11 +12,11 @@ parameters.
 
 Patch-Name: ubuntu-speed-zsys-history.patch
 ---
- util/grub.d/10_linux_zfs.in | 77 +++++++++++++++++++++++++++----------
+ util/grub.d/10_linux_zfs.in | 77 ++++++++++++++++++++++++++++++++-------------
  1 file changed, 56 insertions(+), 21 deletions(-)
 
 diff --git a/util/grub.d/10_linux_zfs.in b/util/grub.d/10_linux_zfs.in
-index 4c48abef0..712d83280 100755
+index 4c48abe..712d832 100755
 --- a/util/grub.d/10_linux_zfs.in
 +++ b/util/grub.d/10_linux_zfs.in
 @@ -803,9 +803,10 @@ zfs_linux_entry () {

--- a/debian/patches/ubuntu-support-initrd-less-boot.patch
+++ b/debian/patches/ubuntu-support-initrd-less-boot.patch
@@ -1,4 +1,3 @@
-From bb9446cdc0550348631a98c1e2dde61a4f84b624 Mon Sep 17 00:00:00 2001
 From: Chris Glass <chris.glass@canonical.com>
 Date: Thu, 10 Nov 2016 13:44:25 -0500
 Subject: UBUNTU: Added knobs to allow non-initrd boot config
@@ -18,7 +17,7 @@ Patch-Name: ubuntu-support-initrd-less-boot.patch
  4 files changed, 38 insertions(+), 4 deletions(-)
 
 diff --git a/docs/grub.info b/docs/grub.info
-index 7cc7d9212..f804b7800 100644
+index 7cc7d92..f804b78 100644
 --- a/docs/grub.info
 +++ b/docs/grub.info
 @@ -1436,6 +1436,19 @@ it must be quoted.  For example:
@@ -42,7 +41,7 @@ index 7cc7d9212..f804b7800 100644
  existing configurations, but have better replacements:
  
 diff --git a/docs/grub.texi b/docs/grub.texi
-index 3ec35d315..1baa0fa20 100644
+index 3ec35d3..1baa0fa 100644
 --- a/docs/grub.texi
 +++ b/docs/grub.texi
 @@ -1541,6 +1541,19 @@ This option sets the English text of the string that will be displayed in
@@ -66,7 +65,7 @@ index 3ec35d315..1baa0fa20 100644
  
  The following options are still accepted for compatibility with existing
 diff --git a/util/grub-mkconfig.in b/util/grub-mkconfig.in
-index 9c1da6477..29bdad0c1 100644
+index 9c1da64..29bdad0 100644
 --- a/util/grub-mkconfig.in
 +++ b/util/grub-mkconfig.in
 @@ -256,7 +256,9 @@ export GRUB_DEFAULT \
@@ -81,7 +80,7 @@ index 9c1da6477..29bdad0c1 100644
  if test "x${grub_cfg}" != "x"; then
    rm -f "${grub_cfg}.new"
 diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
-index dff84edea..aa9666e5a 100644
+index dff84ed..aa9666e 100644
 --- a/util/grub.d/10_linux.in
 +++ b/util/grub.d/10_linux.in
 @@ -193,11 +193,17 @@ EOF

--- a/debian/patches/ubuntu-temp-keep-auto-nvram.patch
+++ b/debian/patches/ubuntu-temp-keep-auto-nvram.patch
@@ -1,4 +1,3 @@
-From 2779bcc00378914fe86fbd2b60e1bce4fdb965fb Mon Sep 17 00:00:00 2001
 From: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
 Date: Tue, 16 Jul 2019 09:52:10 -0400
 Subject: UBUNTU: Temporarily keep grub-install's --auto-nvram.
@@ -10,7 +9,7 @@ Patch-Name: ubuntu-temp-keep-auto-nvram.patch
  1 file changed, 3 insertions(+)
 
 diff --git a/util/grub-install.c b/util/grub-install.c
-index 63462e4e0..bf8eb65b3 100644
+index 63462e4..bf8eb65 100644
 --- a/util/grub-install.c
 +++ b/util/grub-install.c
 @@ -98,6 +98,7 @@ enum

--- a/debian/patches/ubuntu-tpm-unknown-error-non-fatal.patch
+++ b/debian/patches/ubuntu-tpm-unknown-error-non-fatal.patch
@@ -1,8 +1,7 @@
-From 0a30e40f057d4909ddb9f7d55c47a390d9c322d4 Mon Sep 17 00:00:00 2001
 From: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
 Date: Fri, 25 Oct 2019 10:25:04 -0400
-Subject: tpm: Pass unknown error as non-fatal, but debug print the error we
- got
+Subject: tpm: Pass unknown error as non-fatal,
+ but debug print the error we got
 
 Signed-off-by: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
 Patch-Name: ubuntu-tpm-unknown-error-non-fatal.patch
@@ -11,7 +10,7 @@ Patch-Name: ubuntu-tpm-unknown-error-non-fatal.patch
  1 file changed, 8 insertions(+), 4 deletions(-)
 
 diff --git a/grub-core/commands/efi/tpm.c b/grub-core/commands/efi/tpm.c
-index 32909c192..fdbaaee19 100644
+index 32909c1..fdbaaee 100644
 --- a/grub-core/commands/efi/tpm.c
 +++ b/grub-core/commands/efi/tpm.c
 @@ -155,7 +155,8 @@ grub_tpm1_execute (grub_efi_handle_t tpm_handle,

--- a/debian/patches/ubuntu-zfs-enhance-support.patch
+++ b/debian/patches/ubuntu-zfs-enhance-support.patch
@@ -1,4 +1,3 @@
-From bdc1aad90a89af51e043f5bf9dc84019ad2cb75b Mon Sep 17 00:00:00 2001
 From: Didier Roche <didrocks@ubuntu.com>
 Date: Fri, 12 Jul 2019 11:06:06 -0400
 Subject: UBUNTU: Enhance ZFS grub support
@@ -22,12 +21,12 @@ Signed-off-by: Didier Roche <didier.roche@canonical.com>
 ---
  Makefile.util.def           |   7 +
  util/grub.d/10_linux.in     |   4 +
- util/grub.d/10_linux_zfs.in | 964 ++++++++++++++++++++++++++++++++++++
+ util/grub.d/10_linux_zfs.in | 964 ++++++++++++++++++++++++++++++++++++++++++++
  3 files changed, 975 insertions(+)
  create mode 100755 util/grub.d/10_linux_zfs.in
 
 diff --git a/Makefile.util.def b/Makefile.util.def
-index 969d32f00..bac85e284 100644
+index 969d32f..bac85e2 100644
 --- a/Makefile.util.def
 +++ b/Makefile.util.def
 @@ -482,6 +482,13 @@ script = {
@@ -45,7 +44,7 @@ index 969d32f00..bac85e284 100644
    name = '10_xnu';
    common = util/grub.d/10_xnu.in;
 diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
-index 4532266be..a75096609 100644
+index 4532266..a750966 100644
 --- a/util/grub.d/10_linux.in
 +++ b/util/grub.d/10_linux.in
 @@ -71,6 +71,10 @@ case x"$GRUB_FS" in
@@ -61,7 +60,7 @@ index 4532266be..a75096609 100644
  	LINUX_ROOT_DEVICE="ZFS=${rpool}${bootfs%/}"
 diff --git a/util/grub.d/10_linux_zfs.in b/util/grub.d/10_linux_zfs.in
 new file mode 100755
-index 000000000..5ec65fa94
+index 0000000..5ec65fa
 --- /dev/null
 +++ b/util/grub.d/10_linux_zfs.in
 @@ -0,0 +1,964 @@

--- a/debian/patches/uefi-firmware-setup.patch
+++ b/debian/patches/uefi-firmware-setup.patch
@@ -1,4 +1,3 @@
-From c52b294d6c9b8ddeaf83efc181d405ce9d9784dc Mon Sep 17 00:00:00 2001
 From: Steve Langasek <steve.langasek@ubuntu.com>
 Date: Mon, 13 Jan 2014 12:13:12 +0000
 Subject: Output a menu entry for firmware setup on UEFI FastBoot systems
@@ -8,13 +7,13 @@ Last-Update: 2015-09-04
 
 Patch-Name: uefi-firmware-setup.patch
 ---
- Makefile.util.def               |  6 +++++
- util/grub.d/30_uefi-firmware.in | 46 +++++++++++++++++++++++++++++++++
+ Makefile.util.def               |  6 ++++++
+ util/grub.d/30_uefi-firmware.in | 46 +++++++++++++++++++++++++++++++++++++++++
  2 files changed, 52 insertions(+)
  create mode 100644 util/grub.d/30_uefi-firmware.in
 
 diff --git a/Makefile.util.def b/Makefile.util.def
-index eec1924b0..ce133e694 100644
+index eec1924..ce133e6 100644
 --- a/Makefile.util.def
 +++ b/Makefile.util.def
 @@ -526,6 +526,12 @@ script = {
@@ -32,7 +31,7 @@ index eec1924b0..ce133e694 100644
    common = util/grub.d/40_custom.in;
 diff --git a/util/grub.d/30_uefi-firmware.in b/util/grub.d/30_uefi-firmware.in
 new file mode 100644
-index 000000000..3c9f533d8
+index 0000000..3c9f533
 --- /dev/null
 +++ b/util/grub.d/30_uefi-firmware.in
 @@ -0,0 +1,46 @@

--- a/debian/patches/uefi-secure-boot-cryptomount.patch
+++ b/debian/patches/uefi-secure-boot-cryptomount.patch
@@ -1,5 +1,4 @@
-From d930e63990e779ac731e350ce1e372738bb28e24 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?Herv=C3=A9=20Werner?= <dud225@hotmail.com>
+From: =?utf-8?q?Herv=C3=A9_Werner?= <dud225@hotmail.com>
 Date: Mon, 28 Jan 2019 17:24:23 +0100
 Subject: Fix setup on Secure Boot systems where cryptodisk is in use
 
@@ -19,7 +18,7 @@ Patch-Name: uefi-secure-boot-cryptomount.patch
  1 file changed, 17 insertions(+)
 
 diff --git a/util/grub-install.c b/util/grub-install.c
-index 030464645..4bad8de61 100644
+index 0304646..4bad8de 100644
 --- a/util/grub-install.c
 +++ b/util/grub-install.c
 @@ -1546,6 +1546,23 @@ main (int argc, char *argv[])

--- a/debian/patches/vsnprintf-upper-case-hex.patch
+++ b/debian/patches/vsnprintf-upper-case-hex.patch
@@ -1,4 +1,3 @@
-From 7e2eb946ff17cf3b8850d317ce15997c2f70ca05 Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@ubuntu.com>
 Date: Mon, 11 Mar 2019 11:15:12 +0000
 Subject: Add %X to grub_vsnprintf_real and friends
@@ -18,7 +17,7 @@ Patch-Name: vsnprintf-upper-case-hex.patch
  1 file changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/grub-core/kern/misc.c b/grub-core/kern/misc.c
-index 3b633d51f..18cad5803 100644
+index 3b633d5..18cad58 100644
 --- a/grub-core/kern/misc.c
 +++ b/grub-core/kern/misc.c
 @@ -588,7 +588,7 @@ grub_divmod64 (grub_uint64_t n, grub_uint64_t d, grub_uint64_t *r)

--- a/debian/patches/vt-handoff.patch
+++ b/debian/patches/vt-handoff.patch
@@ -1,4 +1,3 @@
-From abb985dff3ac53186817fd9c84d8addf20cd1613 Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@ubuntu.com>
 Date: Mon, 13 Jan 2014 12:13:30 +0000
 Subject: Add configure option to use vt.handoff=7
@@ -19,7 +18,7 @@ Patch-Name: vt-handoff.patch
  3 files changed, 65 insertions(+), 2 deletions(-)
 
 diff --git a/configure.ac b/configure.ac
-index dbc429ce0..e382c7480 100644
+index dbc429c..e382c74 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -1890,6 +1890,17 @@ else
@@ -41,7 +40,7 @@ index dbc429ce0..e382c7480 100644
  
  AC_SUBST([FONT_SOURCE])
 diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
-index 09393c28e..cc2dd855a 100644
+index 09393c2..cc2dd85 100644
 --- a/util/grub.d/10_linux.in
 +++ b/util/grub.d/10_linux.in
 @@ -24,6 +24,7 @@ ubuntu_recovery="@UBUNTU_RECOVERY@"
@@ -101,7 +100,7 @@ index 09393c28e..cc2dd855a 100644
  # FIXME: We need an interface to select vesafb in case efifb can't be used.
  if [ "x$GRUB_GFXPAYLOAD_LINUX" != x ] || [ "$gfxpayload_dynamic" = 0 ]; then
 diff --git a/util/grub.d/10_linux_zfs.in b/util/grub.d/10_linux_zfs.in
-index 8cd7d1285..48a4e6897 100755
+index 8cd7d12..48a4e68 100755
 --- a/util/grub.d/10_linux_zfs.in
 +++ b/util/grub.d/10_linux_zfs.in
 @@ -23,6 +23,7 @@ ubuntu_recovery="@UBUNTU_RECOVERY@"

--- a/debian/patches/wubi-no-windows.patch
+++ b/debian/patches/wubi-no-windows.patch
@@ -1,4 +1,3 @@
-From 1c9945b04f0f47e347710f3f1d12950cd4d2a48d Mon Sep 17 00:00:00 2001
 From: Colin Watson <cjwatson@ubuntu.com>
 Date: Mon, 13 Jan 2014 12:13:24 +0000
 Subject: Skip Windows os-prober entries on Wubi systems
@@ -19,7 +18,7 @@ Patch-Name: wubi-no-windows.patch
  1 file changed, 19 insertions(+)
 
 diff --git a/util/grub.d/30_os-prober.in b/util/grub.d/30_os-prober.in
-index b7e1147c4..271044f59 100644
+index b7e1147..271044f 100644
 --- a/util/grub.d/30_os-prober.in
 +++ b/util/grub.d/30_os-prober.in
 @@ -110,6 +110,8 @@ EOF

--- a/debian/patches/zpool-full-device-name.patch
+++ b/debian/patches/zpool-full-device-name.patch
@@ -1,4 +1,3 @@
-From da9b6788c5db3379adf19f0b43d99c49ba0b2650 Mon Sep 17 00:00:00 2001
 From: Chad MILLER <chad.miller@canonical.com>
 Date: Thu, 27 Oct 2016 17:15:07 -0400
 Subject: Tell zpool to emit full device names
@@ -20,7 +19,7 @@ Patch-Name: zpool-full-device-name.patch
  1 file changed, 1 insertion(+)
 
 diff --git a/grub-core/osdep/unix/getroot.c b/grub-core/osdep/unix/getroot.c
-index 46d7116c6..da102918d 100644
+index 46d7116..da10291 100644
 --- a/grub-core/osdep/unix/getroot.c
 +++ b/grub-core/osdep/unix/getroot.c
 @@ -243,6 +243,7 @@ grub_util_find_root_devices_from_poolname (char *poolname)

--- a/grub-initrd-fallback.service
+++ b/grub-initrd-fallback.service
@@ -2,6 +2,8 @@
 Description=GRUB failed boot detection
 After=local-fs.target
 After=grub-common.service
+After=sleep.target
+ConditionPathExists=/boot/grub/grub.cfg
 
 [Service]
 Type=oneshot

--- a/util/grub.d/10_linux.in
+++ b/util/grub.d/10_linux.in
@@ -160,6 +160,12 @@ if [ "$vt_handoff" = 1 ]; then
 fi
 
 if [ x"$GRUB_FORCE_PARTUUID" != x ]; then
+    gettext_printf "GRUB_FORCE_PARTUUID is set, will attempt initrdless boot\n" >&2
+    cat << EOF
+#
+# GRUB_FORCE_PARTUUID is set, will attempt initrdless boot
+# Upon panic fallback to booting with initrd
+EOF
    echo "set partuuid=${GRUB_FORCE_PARTUUID}"
 fi
 
@@ -245,6 +251,8 @@ EOF
         linux_root_device_thisversion="PARTUUID=${GRUB_FORCE_PARTUUID}"
     fi
     message="$(gettext_printf "Loading initial ramdisk ...")"
+    initrdlessfail_msg="$(gettext_printf "GRUB_FORCE_PARTUUID set, initrdless boot failed. Attempting with initrd.")"
+    initrdlesstry_msg="$(gettext_printf "GRUB_FORCE_PARTUUID set, attempting initrdless boot.")"
     initrd_path=
     for i in ${initrd}; do
         initrd_path="${initrd_path} ${rel_dirname}/${i}"
@@ -256,6 +264,7 @@ EOF
     if test -n "${initrd}" && [ x"$GRUB_FORCE_PARTUUID" != x ]; then
         sed "s/^/$submenu_indentation/" << EOF
 	if [ "\${initrdfail}" = 1 ]; then
+	  echo	'$(echo "$initrdlessfail_msg" | grub_quote)'
 	  linux	${rel_dirname}/${basename} root=${linux_root_device_thisversion} ro ${args}
 EOF
         if [ x"$quiet_boot" = x0 ] || [ x"$type" != xsimple ]; then
@@ -266,6 +275,7 @@ EOF
         sed "s/^/$submenu_indentation/" << EOF
 	  initrd	$(echo $initrd_path)
 	else
+	  echo	'$(echo "$initrdlesstry_msg" | grub_quote)'
 	  linux	${rel_dirname}/${basename} root=${linux_root_device_thisversion} ro ${args} panic=-1
 EOF
         if [ -n "$initrd_path_only_early" ]; then


### PR DESCRIPTION
Conflict was between our change in `grub-initrd-fallback.service`:
```
commit e6b3c307e7114e4b41c476a2cefce3a054a24674
Author: Paul Dagnelie <paul.dagnelie@delphix.com>
Date:   Fri Aug 6 12:16:54 2021 -0700

    DLPX-76797 grub-initrd-fallback.service fails on Ubuntu 20.04 (#19)

diff --git a/grub-initrd-fallback.service b/grub-initrd-fallback.service
index fb0b76e193..93271dbfa9 100644
--- a/grub-initrd-fallback.service
+++ b/grub-initrd-fallback.service
@@ -8,6 +8,3 @@ Type=oneshot
 ExecStart=/usr/bin/grub-editenv /boot/grub/grubenv unset initrdfail
 ExecStart=/usr/bin/grub-editenv /boot/grub/grubenv unset prev_entry
 TimeoutSec=0
-
-[Install]
-WantedBy=multi-user.target rescue.target emergency.target
```
And upstream change:
```
diff --git a/grub-initrd-fallback.service b/grub-initrd-fallback.service
index fb0b76e193..59d1a62c2a 100644
--- a/grub-initrd-fallback.service
+++ b/grub-initrd-fallback.service
@@ -2,6 +2,8 @@
 Description=GRUB failed boot detection
 After=local-fs.target
 After=grub-common.service
+After=sleep.target
+ConditionPathExists=/boot/grub/grub.cfg

 [Service]
 Type=oneshot
@@ -10,4 +12,4 @@ ExecStart=/usr/bin/grub-editenv /boot/grub/grubenv unset prev_entry
 TimeoutSec=0

 [Install]
-WantedBy=multi-user.target rescue.target emergency.target
+WantedBy=multi-user.target rescue.target emergency.target sleep.target
```

We discard the upstream changes in the `[Install]` section since we do not want this service running on our systems.

## Testing
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6515/