### PR TITLE
Backport Remove environment block automated failover to 6.0.12.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1814,14 +1814,6 @@ if test x"$libzfs_excuse" = x ; then
   LIBNVPAIR="-lnvpair"
   AC_DEFINE([HAVE_LIBNVPAIR], [1],
             [Define to 1 if you have the NVPAIR library.])
-
-  AC_CHECK_LIB([zfs], [zpool_get_bootenv],
-               [libzfs_have_bootenv="yes"],
-	       [])
-  if test x"$libzfs_have_bootenv" = xyes ; then
-    AC_DEFINE([HAVE_LIBZFS_BOOTENV], [1],
-              [Define to 1 if you have a version of the ZFS library with bootenv support.])
-  fi
 fi
 
 AC_SUBST([LIBZFS])

--- a/debian/rules
+++ b/debian/rules
@@ -35,8 +35,7 @@ confflags = \
 	PACKAGE_VERSION="$(deb_version)" PACKAGE_STRING="GRUB $(deb_version)" \
 	CC=$(CC) TARGET_CC=$(CC) \
 	--enable-grub-mkfont \
-	--disable-grub-emu-usb \
-	--enable-libzfs=yes
+	--disable-grub-emu-usb
 substvars =
 
 AUTOGEN_DEB_FILES = config templates preinst postinst postrm dirs install links maintscript

--- a/grub-core/commands/loadenv.c
+++ b/grub-core/commands/loadenv.c
@@ -84,105 +84,6 @@ open_envblk_file (char *filename, int untrusted)
   return file;
 }
 
-static grub_file_t
-open_envblk_block (grub_fs_t fs, grub_device_t dev, int untrusted)
-{
-  if (fs->fs_envblk_open) {
-    /*
-     * The filters that are disabled will be re-enabled by the call to
-     * grub_file_envblk_open() after this particular file is opened.
-     */
-    grub_file_filter_disable_compression ();
-    if (untrusted)
-      grub_file_filter_disable_pubkey ();
-    return grub_file_envblk_open (fs, dev);
-  }
-  return NULL;
-}
-
-static grub_file_t
-open_envblk (grub_extcmd_context_t ctxt, int untrusted)
-{
-  struct grub_arg_list *state = ctxt->state;
-  grub_file_t file = NULL;
-  grub_device_t device = NULL;
-  const char *source;
-  grub_fs_t fs = NULL;
-  char *filename = state[0].set ? state[0].arg : NULL;
-
-  source = grub_env_get ("grubenv_src");
-  if (! source || ! grub_strcmp (source, GRUB_ENVBLK_SRC_BLK))
-    {
-      char *device_name;
-      const char *prefix;
-      grub_dprintf ("loadenv", "checking for envblk\n");
-
-      prefix = grub_env_get ("prefix");
-      if (! prefix)
-        {
-          grub_error (GRUB_ERR_FILE_NOT_FOUND, N_("variable `%s' isn't set"), "prefix");
-          return NULL;
-        }
-
-      device_name = grub_file_get_device_name (prefix);
-      if (grub_errno)
-	return NULL;
-
-      device = grub_device_open (device_name);
-      if (! device) {
-	grub_free (device_name);
-	return NULL;
-      }
-
-      fs = grub_fs_probe (device);
-      if (! fs) {
-	grub_device_close (device);
-	grub_free (device_name);
-	return NULL;
-      }
-
-      /* We have to reopen the device here because it was closed in grub_fs_probe. */
-      device = grub_device_open (device_name);
-      grub_free (device_name);
-      if (! device)
-	return NULL;
-
-    }
-  if (! source)
-    {
-      if (fs->fs_envblk_open)
-	{
-	  source = GRUB_ENVBLK_SRC_BLK;
-	  grub_dprintf ("loadenv", "envblk support detected\n");
-	}
-      else
-	{
-	  source = GRUB_ENVBLK_SRC_FILE;
-	  grub_dprintf ("loadenv", "envblk support not detected\n");
-	}
-    }
-
-  if (! grub_strcmp (source, GRUB_ENVBLK_SRC_FILE))
-    {
-      if (device)
-        grub_device_close (device);
-      file = open_envblk_file (filename, untrusted);
-
-      if (! file)
-	return NULL;
-    }
-  else if (! grub_strcmp (source, GRUB_ENVBLK_SRC_BLK))
-    {
-      file = open_envblk_block (fs, device, untrusted);
-      if (! file)
-	{
-	  grub_device_close (device);
-	  return NULL;
-	}
-    }
-  return file;
-}
-
 static grub_envblk_t
 read_envblk_file (grub_file_t file)
 {
@@ -270,7 +171,7 @@ grub_cmd_load_env (grub_extcmd_context_t ctxt, int argc, char **args)
   whitelist.list = args;
 
   /* state[0] is the -f flag; state[1] is the --skip-sig flag */
-  file = open_envblk (ctxt, state[1].set);
+  file = open_envblk_file ((state[0].set) ? state[0].arg : 0, state[1].set);
   if (! file)
     return grub_errno;
 
@@ -301,10 +202,11 @@ grub_cmd_list_env (grub_extcmd_context_t ctxt,
 		   int argc __attribute__ ((unused)),
 		   char **args __attribute__ ((unused)))
 {
+  struct grub_arg_list *state = ctxt->state;
   grub_file_t file;
   grub_envblk_t envblk;
 
-  file = open_envblk (ctxt, 0);
+  file = open_envblk_file ((state[0].set) ? state[0].arg : 0, 0);
   if (! file)
     return grub_errno;
 
@@ -476,6 +378,7 @@ save_env_read_hook (grub_disk_addr_t sector, unsigned offset, unsigned length,
 static grub_err_t
 grub_cmd_save_env (grub_extcmd_context_t ctxt, int argc, char **args)
 {
+  struct grub_arg_list *state = ctxt->state;
   grub_file_t file;
   grub_envblk_t envblk;
   struct grub_cmd_save_env_ctx ctx = {
@@ -486,7 +389,8 @@ grub_cmd_save_env (grub_extcmd_context_t ctxt, int argc, char **args)
   if (! argc)
     return grub_error (GRUB_ERR_BAD_ARGUMENT, "no variable is specified");
 
-  file = open_envblk (ctxt, 1 /* allow untrusted */);
+  file = open_envblk_file ((state[0].set) ? state[0].arg : 0,
+                           1 /* allow untrusted */);
   if (! file)
     return grub_errno;
 
@@ -503,7 +407,7 @@ grub_cmd_save_env (grub_extcmd_context_t ctxt, int argc, char **args)
   if (! envblk)
     goto fail;
 
-  if (! grub_file_envblk (file) && check_blocklists (envblk, ctx.head, file))
+  if (check_blocklists (envblk, ctx.head, file))
     goto fail;
 
   while (argc)
@@ -526,15 +430,7 @@ grub_cmd_save_env (grub_extcmd_context_t ctxt, int argc, char **args)
       args++;
     }
 
-  if (grub_file_envblk (file))
-    {
-      grub_file_seek (file, 0);
-      file->fs->fs_envblk_write (file, grub_envblk_buffer (envblk), grub_envblk_size (envblk));
-    }
-  else
-    {
-      write_blocklists (envblk, ctx.head, file);
-    }
+  write_blocklists (envblk, ctx.head, file);
 
  fail:
   if (envblk)

--- a/grub-core/kern/misc.c
+++ b/grub-core/kern/misc.c
@@ -519,19 +519,6 @@ grub_strlen (const char *s)
   return p - s;
 }
 
-grub_size_t
-grub_strnlen (const char *s, grub_size_t maxlen)
-{
-  const char *p = s;
-  grub_size_t idx = 0;
-  while (*p && idx < maxlen)
-    {
-      p++;
-      idx++;
-    }
-  return idx;
-}
-
 static inline void
 grub_reverse (char *str)
 {

--- a/grub-core/lib/envblk.c
+++ b/grub-core/lib/envblk.c
@@ -224,7 +224,7 @@ grub_envblk_delete (grub_envblk_t envblk, const char *name)
 }
 
 void
-grub_envblk_iterate (const grub_envblk_t envblk,
+grub_envblk_iterate (grub_envblk_t envblk,
                      void *hook_data,
                      int hook (const char *name, const char *value, void *hook_data))
 {

--- a/include/grub/file.h
+++ b/include/grub/file.h
@@ -60,9 +60,6 @@ struct grub_file
 
   /* Caller-specific data passed to the read hook.  */
   void *read_hook_data;
-
-  /* If the file is an FS's envblock, which uses separate functions for interaction. */
-  int envblk;
 };
 typedef struct grub_file *grub_file_t;
 
@@ -139,7 +136,6 @@ grub_ssize_t EXPORT_FUNC(grub_file_read) (grub_file_t file, void *buf,
 					  grub_size_t len);
 grub_off_t EXPORT_FUNC(grub_file_seek) (grub_file_t file, grub_off_t offset);
 grub_err_t EXPORT_FUNC(grub_file_close) (grub_file_t file);
-grub_file_t EXPORT_FUNC(grub_file_envblk_open) (grub_fs_t fs, grub_device_t device);
 
 /* Return value of grub_file_size() in case file size is unknown. */
 #define GRUB_FILE_SIZE_UNKNOWN	 0xffffffffffffffffULL
@@ -160,12 +156,6 @@ static inline int
 grub_file_seekable (const grub_file_t file)
 {
   return !file->not_easily_seekable;
-}
-
-static inline int
-grub_file_envblk (const grub_file_t file)
-{
-  return file->envblk;
 }
 
 grub_file_t

--- a/include/grub/fs.h
+++ b/include/grub/fs.h
@@ -96,18 +96,6 @@ struct grub_fs
   /* Whether blocklist installs have a chance to work.  */
   int blocklist_install;
 #endif
-
-  /*
-   * The envblk functions are defined on filesystems that need to handle
-   * grub-writable files in a special way. This is most commonly the case for
-   * CoW filesystems like btrfs and ZFS.  The normal read and close functions
-   * should detect that they are being called on a special file and act
-   * appropriately.
-   */
-  grub_err_t (*fs_envblk_open) (struct grub_file *file);
-  grub_ssize_t (*fs_envblk_read) (struct grub_file *file, char *buf, grub_size_t len);
-  grub_err_t (*fs_envblk_write) (struct grub_file *file, char *buf, grub_size_t len);
-  grub_err_t (*fs_envblk_close) (struct grub_file *file);
 };
 typedef struct grub_fs *grub_fs_t;
 

--- a/include/grub/lib/envblk.h
+++ b/include/grub/lib/envblk.h
@@ -21,9 +21,6 @@
 
 #define GRUB_ENVBLK_SIGNATURE	"# GRUB Environment Block\n"
 #define GRUB_ENVBLK_DEFCFG	"grubenv"
-#define GRUB_ENVBLK_SRC_BLK	"block"
-#define GRUB_ENVBLK_SRC_FILE	"file"
-#define GRUB_ENVBLK_DEFAULT_SIZE      1024
 
 #ifndef ASM_FILE
 

--- a/include/grub/misc.h
+++ b/include/grub/misc.h
@@ -286,7 +286,6 @@ char *EXPORT_FUNC(grub_strdup) (const char *s) WARN_UNUSED_RESULT;
 char *EXPORT_FUNC(grub_strndup) (const char *s, grub_size_t n) WARN_UNUSED_RESULT;
 void *EXPORT_FUNC(grub_memset) (void *s, int c, grub_size_t n);
 grub_size_t EXPORT_FUNC(grub_strlen) (const char *s) WARN_UNUSED_RESULT;
-grub_size_t EXPORT_FUNC(grub_strnlen) (const char *s, grub_size_t maxlen) WARN_UNUSED_RESULT;
 int EXPORT_FUNC(grub_printf) (const char *fmt, ...) __attribute__ ((format (GNU_PRINTF, 1, 2)));
 int EXPORT_FUNC(grub_printf_) (const char *fmt, ...) __attribute__ ((format (GNU_PRINTF, 1, 2)));
 

--- a/include/grub/util/install.h
+++ b/include/grub/util/install.h
@@ -241,9 +241,6 @@ grub_install_get_blocklist (grub_device_t root_dev,
 			    void *hook_data);
 
 void
-grub_util_create_envblk_buffer (char *, size_t);
-
-void
 grub_util_create_envblk_file (const char *name);
 
 void

--- a/include/grub/util/libnvpair.h
+++ b/include/grub/util/libnvpair.h
@@ -27,69 +27,11 @@
 
 #include <stdio.h>	/* FILE */
 
-typedef enum {
-        DATA_TYPE_DONTCARE = -1,
-        DATA_TYPE_UNKNOWN = 0,
-        DATA_TYPE_BOOLEAN,
-	DATA_TYPE_BYTE,
-        DATA_TYPE_INT16,
-        DATA_TYPE_UINT16,
-	DATA_TYPE_INT32,
-        DATA_TYPE_UINT32,
-        DATA_TYPE_INT64,
-	DATA_TYPE_UINT64,
-        DATA_TYPE_STRING,
-        DATA_TYPE_BYTE_ARRAY,
-        DATA_TYPE_INT16_ARRAY,
-	DATA_TYPE_UINT16_ARRAY,
-        DATA_TYPE_INT32_ARRAY,
-        DATA_TYPE_UINT32_ARRAY,
-        DATA_TYPE_INT64_ARRAY,
-	DATA_TYPE_UINT64_ARRAY,
-        DATA_TYPE_STRING_ARRAY,
-        DATA_TYPE_HRTIME,
-	DATA_TYPE_NVLIST,
-        DATA_TYPE_NVLIST_ARRAY,
-        DATA_TYPE_BOOLEAN_VALUE,
-        DATA_TYPE_INT8,
-	DATA_TYPE_UINT8,
-        DATA_TYPE_BOOLEAN_ARRAY,
-        DATA_TYPE_INT8_ARRAY,
-#if !defined(_KERNEL) && !defined(_STANDALONE)
-        DATA_TYPE_UINT8_ARRAY,
-        DATA_TYPE_DOUBLE
-#else
-     	DATA_TYPE_UINT8_ARRAY
-#endif
-} data_type_t;
-
 typedef void nvlist_t;
-typedef void nvpair_t;
-
-/* nvlist pack encoding */
-#define NV_ENCODE_NATIVE        0
-#define NV_ENCODE_XDR           1
-
-/* nvlist persistent unique name flags, stored in nvl_nvflags */
-#define NV_UNIQUE_NAME          0x1
-#define NV_UNIQUE_NAME_TYPE     0x2
-
-int nvlist_alloc (nvlist_t **, unsigned int, int);
-void nvlist_free (nvlist_t *);
-int nvlist_size (nvlist_t *, size_t *, int);
 
 int nvlist_lookup_string (nvlist_t *, const char *, char **);
 int nvlist_lookup_nvlist (nvlist_t *, const char *, nvlist_t **);
 int nvlist_lookup_nvlist_array (nvlist_t *, const char *, nvlist_t ***, unsigned int *);
-int nvlist_lookup_uint64 (nvlist_t *, const char *, u_int64_t *);
-
-nvpair_t *nvlist_next_nvpair (nvlist_t *, nvpair_t *);
-char *nvpair_name (nvpair_t *);
-data_type_t nvpair_type (nvpair_t *);
-int nvpair_value_string (nvpair_t *, char **);
-
-int nvlist_add_string (nvlist_t *, const char *, const char *);
-int nvlist_add_uint64 (nvlist_t *, const char *, u_int64_t);
 
 #endif /* ! HAVE_LIBNVPAIR_H */
 

--- a/include/grub/util/libzfs.h
+++ b/include/grub/util/libzfs.h
@@ -40,24 +40,6 @@ extern int zpool_get_physpath (zpool_handle_t *, const char *);
 
 extern nvlist_t *zpool_get_config (zpool_handle_t *, nvlist_t **);
 
-extern libzfs_handle_t *zpool_get_handle (zpool_handle_t *);
-
-extern int zpool_set_bootenv (zpool_handle_t *, const nvlist_t*);
-extern int zpool_get_bootenv (zpool_handle_t *, nvlist_t **);
-
-extern int libzfs_errno (libzfs_handle_t *);
-
-/*
- * libzfs errors
- */
-typedef enum zfs_error {
-	EZFS_SUCCESS = 0,	/* no error -- success */
-	EZFS_NOMEM = 2000,	/* out of memory */
-	EZFS_IOC_NOTSUPPORTED = 2079,  /* operation not supported by zfs module */
-	EZFS_REBUILDING,	/* resilvering (sequential reconstrution) */
-	EZFS_UNKNOWN = 2089
-} zfs_error_t;
-
 #endif /* ! HAVE_LIBZFS_H */
 
 libzfs_handle_t *grub_get_libzfs_handle (void);

--- a/include/grub/zfs/vdev_impl.h
+++ b/include/grub/zfs/vdev_impl.h
@@ -23,39 +23,34 @@
 #ifndef _SYS_VDEV_IMPL_H
 #define	_SYS_VDEV_IMPL_H
 
-#define	VDEV_PAD_SIZE		(8 << 10)
+#define	VDEV_SKIP_SIZE		(8 << 10)
+#define	VDEV_BOOT_HEADER_SIZE	(8 << 10)
 #define	VDEV_PHYS_SIZE		(112 << 10)
 #define	VDEV_UBERBLOCK_RING	(128 << 10)
+
+/* ZFS boot block */
+#define	VDEV_BOOT_MAGIC		0x2f5b007b10cULL
+#define	VDEV_BOOT_VERSION	1		/* version number	*/
+
+typedef struct vdev_boot_header {
+	grub_uint64_t	vb_magic;		/* VDEV_BOOT_MAGIC	*/
+	grub_uint64_t	vb_version;		/* VDEV_BOOT_VERSION	*/
+	grub_uint64_t	vb_offset;		/* start offset	(bytes) */
+	grub_uint64_t	vb_size;		/* size (bytes)		*/
+	char		vb_pad[VDEV_BOOT_HEADER_SIZE - 4 * sizeof (grub_uint64_t)];
+} vdev_boot_header_t;
 
 typedef struct vdev_phys {
 	char		vp_nvlist[VDEV_PHYS_SIZE - sizeof (zio_eck_t)];
 	zio_eck_t	vp_zbt;
 } vdev_phys_t;
 
-typedef enum vbe_vers {
-	/* The bootenv file is stored as ascii text in the envblock */
-	VB_RAW = 0,
-
-	/*
-	 * The bootenv file is converted to an nvlist and then packed into the
-	 * envblock.
-	 */
-	VB_NVLIST = 1
-} vbe_vers_t;
-
-typedef struct vdev_boot_envblock {
-	grub_uint64_t	vbe_version;
-	char		vbe_bootenv[VDEV_PAD_SIZE - sizeof (grub_uint64_t) -
-			sizeof (zio_eck_t)];
-	zio_eck_t	vbe_zbt;
-} vdev_boot_envblock_t;
-
 typedef struct vdev_label {
-	char		vl_pad1[VDEV_PAD_SIZE];			/*  8K */
-	vdev_boot_envblock_t	vl_be;				/*  8K */
+	char		vl_pad[VDEV_SKIP_SIZE];			/*   8K	*/
+	vdev_boot_header_t vl_boot_header;			/*   8K	*/
 	vdev_phys_t	vl_vdev_phys;				/* 112K	*/
 	char		vl_uberblock[VDEV_UBERBLOCK_RING];	/* 128K	*/
-} vdev_label_t;						/* 256K total */
+} vdev_label_t;							/* 256K total */
 
 /*
  * Size and offset of embedded boot loader region on each label.

--- a/util/editenv.c
+++ b/util/editenv.c
@@ -29,16 +29,7 @@
 #include <errno.h>
 #include <string.h>
 
-
-void
-grub_util_create_envblk_buffer (char *buf, size_t size)
-{
-  if (size < GRUB_ENVBLK_DEFAULT_SIZE)
-    grub_util_error (_("Envblock buffer too small"));
-  memcpy (buf, GRUB_ENVBLK_SIGNATURE, sizeof (GRUB_ENVBLK_SIGNATURE) - 1);
-  memset (buf + sizeof (GRUB_ENVBLK_SIGNATURE) - 1, '#',
-    GRUB_ENVBLK_DEFAULT_SIZE - sizeof (GRUB_ENVBLK_SIGNATURE) + 1);
-}
+#define DEFAULT_ENVBLK_SIZE	1024
 
 void
 grub_util_create_envblk_file (const char *name)
@@ -47,8 +38,7 @@ grub_util_create_envblk_file (const char *name)
   char *buf;
   char *namenew;
 
-  buf = xmalloc (GRUB_ENVBLK_DEFAULT_SIZE);
-  grub_util_create_envblk_buffer(buf, GRUB_ENVBLK_DEFAULT_SIZE);
+  buf = xmalloc (DEFAULT_ENVBLK_SIZE);
 
   namenew = xasprintf ("%s.new", name);
   fp = grub_util_fopen (namenew, "wb");
@@ -56,7 +46,11 @@ grub_util_create_envblk_file (const char *name)
     grub_util_error (_("cannot open `%s': %s"), namenew,
 		     strerror (errno));
 
-  if (fwrite (buf, 1, GRUB_ENVBLK_DEFAULT_SIZE, fp) != GRUB_ENVBLK_DEFAULT_SIZE)
+  memcpy (buf, GRUB_ENVBLK_SIGNATURE, sizeof (GRUB_ENVBLK_SIGNATURE) - 1);
+  memset (buf + sizeof (GRUB_ENVBLK_SIGNATURE) - 1, '#',
+          DEFAULT_ENVBLK_SIZE - sizeof (GRUB_ENVBLK_SIGNATURE) + 1);
+
+  if (fwrite (buf, 1, DEFAULT_ENVBLK_SIZE, fp) != DEFAULT_ENVBLK_SIZE)
     grub_util_error (_("cannot write to `%s': %s"), namenew,
 		     strerror (errno));
 


### PR DESCRIPTION
This PR removes all the delphix changes from the GRUB logic except for the ones unrelated to automated failover. This is a backport to 6.0.12.0.

http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6495/console Tested in conjunction with recovery-environment PR; failure appears unrelated.