### PR TITLE
DLPX-80189 grub-probe failed during upgrade of kdump-tools package

### DIFF
--- a/debian/update-grub
+++ b/debian/update-grub
@@ -1,3 +1,13 @@
 #!/bin/sh
 set -e
+
+#
+# We don't use this script in the Delphix product to update grub.
+# Instead, we call "grub-mkconfig" explicitly via the product's upgrade
+# code. Additionally, we've seen cases where this is called by package
+# hooks, and result in errors. As a result, we modify the script to be a
+# no-op here, rather than attempt to fix all callers of the script.
+#
+exit 0
+
 exec grub-mkconfig -o /boot/grub/grub.cfg "$@"


### PR DESCRIPTION
Ubuntu systems generally use the "update-grub" script to provide a convenient way for users (both software and human) to update the bootloader whenever it needs to be updated. As a result, various Ubuntu packages leverage this script to update the bootloader when they feel it's appropriate to do so (e.g. in their post-install hooks).

On Delphix systems, though, this script doesn't actually update the bootloader, since we store the bootloader configuration on a separate partition of the root disk (that generally is not mounted). We use a separate partition intentionally to prohibit the bootloader from being modified until our product's upgrade logic is ready for it to be updated.

This means, best case, when the "update-grub" script is run by these package post-install hooks, it silently does nothing; worst case, it can fail and cause cascading failures. Further, we've seen these cascading failures result in customers being unable to perform an upgrade altogether; e.g. due to "update-grub" failing in a package hook, causing the package failing to upgrade, resulting in the upgrade process as a whole failing.

Thus, this change modifies the "update-grub" script such that all it does now is exit with a successful error code. This way, consumers of the script don't have to be modified, and we've removed the potential for this script to fail. Since the bootloader will be updated correctly via the Delphix product's upgrade logic (which doesn't use this script), this change shouldn't actually have any impact on our ability to maintain the bootloader configuration on Delphix systems.