### PR TITLE
DLPX-80189 grub-probe failed during upgrade of kdump-tools package

### DIFF
--- a/grub-core/osdep/unix/getroot.c
+++ b/grub-core/osdep/unix/getroot.c
@@ -296,7 +296,7 @@ grub_util_find_root_devices_from_poolname (char *poolname)
 		&& !sscanf (name, "raidz1%u", &dummy)
 		&& !sscanf (name, "raidz2%u", &dummy)
 		&& !sscanf (name, "raidz3%u", &dummy)
-		&& !strcmp (state, "ONLINE"))
+		&& (!strcmp (state, "ONLINE") || !strcmp (state, "DEGRADED")))
 	      {
 		if (ndevices >= devices_allocated)
 		  {


### PR DESCRIPTION
This change adds support for `DEGRADED` pools and devices, in addition to `ONLINE` pools and devices.