### PR TITLE
TOOL-16646 grub2: remove "Build-Conflicts" so we can build on DE buildserver

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -39,7 +39,6 @@ Build-Depends: debhelper (>= 10~),
  bash-completion,
  libefiboot-dev [any-linux-i386 any-linux-amd64 any-linux-ia64 any-linux-arm any-linux-arm64],
  libefivar-dev [any-linux-i386 any-linux-amd64 any-linux-ia64 any-linux-arm any-linux-arm64],
-Build-Conflicts: autoconf2.13, libzfs-dev, libnvpair-dev
 Standards-Version: 3.9.6
 Homepage: https://www.gnu.org/software/grub/
 Vcs-Git: https://git.launchpad.net/~ubuntu-core-dev/grub/+git/ubuntu


### PR DESCRIPTION
Without this change, we hit the following build failure when building on a Delphix based buildserver:
```
14:20:27  dpkg-deb: building package 'grub2-build-deps' in '../grub2-build-deps_2.04-1ubuntu26.15_amd64.deb'.
14:20:27  
14:20:27  The package has been created.
14:20:27  Attention, the package has been created in the current directory,
14:20:27  not in ".." as indicated by the message above!
14:20:27  Selecting previously unselected package grub2-build-deps.
14:20:27  dpkg: regarding grub2-build-deps_2.04-1ubuntu26.15_amd64.deb containing grub2-build-deps:
14:20:27   grub2-build-deps conflicts with libnvpair-dev
14:20:27    libzfslinux-dev provides libnvpair-dev and is present and installed.
14:20:27  
14:20:27  dpkg: error processing archive grub2-build-deps_2.04-1ubuntu26.15_amd64.deb (--unpack):
14:20:27   conflicting packages - not installing grub2-build-deps
14:20:27  Errors were encountered while processing:
14:20:27   grub2-build-deps_2.04-1ubuntu26.15_amd64.deb
14:20:27  mk-build-deps: dpkg --unpack failed
14:20:27  Error: failed command 'sudo env DEBIAN_FRONTEND=noninteractive mk-build-deps --install --tool=apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes debian/control'
```