### PR TITLE
DLPX-92333 Cherry-pick Delphix commits of grub2 for LTS upgrade

### DIFF
--- a/util/grub-mkconfig_lib.in
+++ b/util/grub-mkconfig_lib.in
@@ -226,6 +226,29 @@ grub_file_is_not_garbage ()
 
 version_sort ()
 {
+  #
+  # Delphix: we define the latest kernel version as the one listed in the
+  # package-list file of the delphix-entire package.
+  #
+  appliance_platform=$(cat /var/lib/delphix-appliance/platform)
+  if [ "x$appliance_platform" = "x" ]; then
+    echo "Error: file /var/lib/delphix-appliance/platform empty or missing" >&2
+    return 1
+  fi
+  delphix_pkgs_list="/usr/share/doc/delphix-entire-${appliance_platform}/packages.list.gz"
+  delphix_latest=$(zcat "$delphix_pkgs_list" | grep '^delphix-kernel-' | cut -d= -f1 | sed 's/delphix-kernel-//')
+  if [ "x$delphix_latest" = "x" ]; then
+    echo "Error: Failed to retrieve latest delphix-kernel version from '$delphix_pkgs_list'" >&2
+    return 1
+  fi
+  
+  for i in "$@" ; do
+    if echo "$i" | grep -q "$delphix_latest\$" ; then
+      echo "$i"
+      return
+    fi
+  done
+  
   LC_ALL=C /usr/lib/grub/grub-sort-version "$@"
 }
 
@@ -300,8 +323,28 @@ version_test_gt ()
 version_find_latest ()
 {
   grub_warn "version_find_latest() is deprecated. Use version_sort() instead."
+  #
+  # Delphix: we define the latest kernel version as the one listed in the
+  # package-list file of the delphix-entire package.
+  #
+  appliance_platform=$(cat /var/lib/delphix-appliance/platform)
+  if [ "x$appliance_platform" = "x" ]; then
+    echo "Error: file /var/lib/delphix-appliance/platform empty or missing" >&2
+    return 1
+  fi
+  delphix_pkgs_list="/usr/share/doc/delphix-entire-${appliance_platform}/packages.list.gz"
+  delphix_latest=$(zcat "$delphix_pkgs_list" | grep '^delphix-kernel-' | cut -d= -f1 | sed 's/delphix-kernel-//')
+  if [ "x$delphix_latest" = "x" ]; then
+    echo "Error: Failed to retrieve latest delphix-kernel version from '$delphix_pkgs_list'" >&2
+    return 1
+  fi
+
   version_find_latest_a=""
   for i in "$@" ; do
+    if echo "$i" | grep -q "$delphix_latest\$" ; then
+      echo "$i"
+      return
+    fi
     if version_test_gt "$i" "$version_find_latest_a" ; then
       version_find_latest_a="$i"
     fi
@@ -412,4 +455,3 @@ grub_tab="	"
 grub_add_tab () {
   sed -e "s/^/$grub_tab/"
 }
-

--- a/util/grub.d/10_linux_zfs.in
+++ b/util/grub.d/10_linux_zfs.in
@@ -998,6 +998,7 @@ echo
                 fi
             fi
 
+            root=$(findmnt / | grep '^/' | awk '{print $2}' | sed 's@^rpool/@@')
             case "${section}" in
                 main)
                     title="${name}"
@@ -1005,7 +1006,7 @@ echo
                     main_dataset="${dataset}"
 
                     kernel_version=$(basename "${kernel}" | sed -e "s,^[^0-9]*-,,g")
-                    zfs_linux_entry 0 "${title}" "simple" "${dataset}" "${device}" "${initrd}" "${kernel}" "${kernel_version}"
+                    zfs_linux_entry 0 "${title}" "simple" "rpool/${root}" "${device}" "${initrd}" "${kernel}" "${kernel_version}"
                     at_least_one_entry=1
                 ;;
                 advanced)
@@ -1021,12 +1022,12 @@ echo
 
                     kernel_version=$(basename "${kernel}" | sed -e "s,^[^0-9]*-,,g")
                     title="$(gettext_printf "%s%s, with Linux %s" "${last_booted_kernel_marker}" "${name}" "${kernel_version}")"
-                    zfs_linux_entry 1 "${title}" "advanced" "${dataset}" "${device}" "${initrd}" "${kernel}" "${kernel_version}"
+                    zfs_linux_entry 1 "${title}" "advanced" "rpool/${root}" "${device}" "${initrd}" "${kernel}" "${kernel_version}"
 
                     GRUB_DISABLE_RECOVERY=${GRUB_DISABLE_RECOVERY:-}
                     if [ "${GRUB_DISABLE_RECOVERY}" != "true" ]; then
                         title="$(gettext_printf "%s%s, with Linux %s (%s)" "${last_booted_kernel_marker}" "${name}" "${kernel_version}" "$(gettext "${GRUB_RECOVERY_TITLE}")")"
-                        zfs_linux_entry 1 "${title}" "recovery" "${dataset}" "${device}" "${initrd}" "${kernel}" "${kernel_version}"
+                        zfs_linux_entry 1 "${title}" "recovery" "rpool/${root}" "${device}" "${initrd}" "${kernel}" "${kernel_version}"
                     fi
                     at_least_one_entry=1
                 ;;


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

grub2’s focal and noble branches have differing histories making it impossible to merge them. Instead, we’ve chosen to pull in noble’s commits and cherry-picking Delphix commits on top of upstream.

The following commits need to be cherry-picked on to os-upgrade now that it tracks the `applied/ubuntu/noble-updates` branch of upstream:
1. https://github.com/delphix/grub2/pull/10
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

1. Cherry-pick https://github.com/delphix/grub2/pull/10. Then, apply the same changes to the `version_sort` function because it replaces the `version_find_latest` function
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

Built the package here: https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/linux-pkg/job/os-upgrade/job/build-package/job/grub2/job/pre-push/5/console
</details>

# Open questions
1. How do I test this change without a 24.04 appliance? Is it okay to defer testing till we can build an appliance? We are operating on the "os-upgrade" branch anyway.
2. Which of these should also be cherry-picked?
https://github.com/delphix/grub2/pull/27
https://github.com/delphix/grub2/pull/19
https://github.com/delphix/grub2/pull/12
3. I also found some PRs related to recovery-environment. Do we need them?

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
