### PR TITLE
DLPX-93019 24.04: grub config contains the wrong root pool reference

### DIFF
--- a/util/grub.d/10_linux_zfs.in
+++ b/util/grub.d/10_linux_zfs.in
@@ -998,6 +998,7 @@ echo
                 fi
             fi
 
+            root=$(findmnt / | grep '^/' | awk '{print $2}' | sed 's@^[^/]*/@@')
             case "${section}" in
                 main)
                     title="${name}"
@@ -1005,7 +1006,7 @@ echo
                     main_dataset="${dataset}"
 
                     kernel_version=$(basename "${kernel}" | sed -e "s,^[^0-9]*-,,g")
-                    zfs_linux_entry 0 "${title}" "simple" "${dataset}" "${device}" "${initrd}" "${kernel}" "${kernel_version}"
+                    zfs_linux_entry 0 "${title}" "simple" "rpool/${root}" "${device}" "${initrd}" "${kernel}" "${kernel_version}"
                     at_least_one_entry=1
                 ;;
                 advanced)
@@ -1021,12 +1022,12 @@ echo
 
                     kernel_version=$(basename "${kernel}" | sed -e "s,^[^0-9]*-,,g")
                     title="$(gettext_printf "%s%s, with Linux %s" "${last_booted_kernel_marker}" "${name}" "${kernel_version}")"
-                    zfs_linux_entry 1 "${title}" "advanced" "${dataset}" "${device}" "${initrd}" "${kernel}" "${kernel_version}"
+                    zfs_linux_entry 1 "${title}" "advanced" "rpool/${root}" "${device}" "${initrd}" "${kernel}" "${kernel_version}"
 
                     GRUB_DISABLE_RECOVERY=${GRUB_DISABLE_RECOVERY:-}
                     if [ "${GRUB_DISABLE_RECOVERY}" != "true" ]; then
                         title="$(gettext_printf "%s%s, with Linux %s (%s)" "${last_booted_kernel_marker}" "${name}" "${kernel_version}" "$(gettext "${GRUB_RECOVERY_TITLE}")")"
-                        zfs_linux_entry 1 "${title}" "recovery" "${dataset}" "${device}" "${initrd}" "${kernel}" "${kernel_version}"
+                        zfs_linux_entry 1 "${title}" "recovery" "rpool/${root}" "${device}" "${initrd}" "${kernel}" "${kernel_version}"
                     fi
                     at_least_one_entry=1
                 ;;


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

A 24.04 engine failed to boot because the grub config had references to the wrong root pool (not rpool, but the reference to the root pool created in the chroot env during appliance-build). For example:
```
[    0.000000] Command line: BOOT_IMAGE=/ROOT/delphix.C0OMBg9/root@/boot/vmlinuz-6.8.0-47-dx2024122401-436f4ae50-generic root=ZFS=delphix.C0OMBg9/ROOT/delphix.C0OMBg9/root ro console=tty0 console=ttyS0,38400n8 mitigations=off ipv6.disable=1 elevator=noop crashkernel=256M,high crashkernel=256M,low init_on_alloc=0 usbcore.nousb=1 nvme_core.io_timeout=4294967295 earlyprintk=ttyS0,38400n8 rootdelay=300
```
This caused a failure to import the pool
```
Begin: Importing ZFS root pool 'delphix.C0OMBg9' ... Begin: Importing pool 'delphix.C0OMBg9' using defaults ... Failure: 1
Failure: 1

Command: /sbin/zpool import -N   'delphix.C0OMBg9'
Message: cannot import 'delphix.C0OMBg9': no such pool available
Error: 1

Failed to import pool 'delphix.C0OMBg9'.
Manually import the pool and exit.
```
On a `develop` engine, this grub config looks like: 
```
[    0.000000] Command line: BOOT_IMAGE=/ROOT/delphix.9rHQ2s3/root@/boot/vmlinuz-5.15.0-1072-dx2024111017-c48e50342-aws root=ZFS=rpool/ROOT/delphix.9rHQ2s3/root ro console=tty0 console=ttyS0,38400n8 mitigations=off ipv6.disable=1 elevator=noop crashkernel=256M,high crashkernel=256M,low init_on_alloc=0 usbcore.nousb=1 nvme_core.io_timeout=4294967295 earlyprintk=ttyS0,38400n8 rootdelay=300
```
Notice that the `root` parameter is rpool. 



Now, according to the grub manual: https://www.gnu.org/software/grub/manual/grub/grub.html#Simple-configuration
> grub-mkconfig does have some limitations. While adding extra custom menu entries to the end of the list can be done by editing /etc/grub.d/40_custom or creating /boot/grub/custom.cfg, changing the order of menu entries or changing their titles may require making complex changes to shell scripts stored in /etc/grub.d/. This may be improved in the future. In the meantime, those who feel that it would be easier to write grub.cfg directly are encouraged to do so (see [Booting](https://www.gnu.org/software/grub/manual/grub/grub.html#Booting), and [Shell-like scripting](https://www.gnu.org/software/grub/manual/grub/grub.html#Shell_002dlike-scripting)), and to disable any system provided by their distribution to automatically run grub-mkconfig.

Since there is no easy way to modify existing menu entries, even the manual recommends modifying the script directly. 
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Modify the script such that the correct pool name is referenced.
</details>


<details>
<summary><h2> Testing Done </h2></summary>

appliance-build: https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build/job/os-upgrade/job/pre-push/81/console
Then, I imported the image into a DCoL and verified that it gets past the boot issue. 
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
