### PR TITLE
DLPX-93247 grub2 build fails on 24.04 DE-based buildserver due to package conflit

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -37,7 +37,7 @@ Build-Depends: debhelper-compat (= 13),
  bash-completion,
  libefiboot-dev [i386 amd64 ia64 x32 armel armhf arm64 riscv64],
  libefivar-dev [i386 amd64 ia64 x32 armel armhf arm64 riscv64],
-Build-Conflicts: autoconf2.13, libzfs-dev, libnvpair-dev
+Build-Conflicts: autoconf2.13, libzfs-dev
 Standards-Version: 3.9.6
 Homepage: https://www.gnu.org/software/grub/
 Vcs-Git: https://git.launchpad.net/~ubuntu-core-dev/grub/+git/ubuntu


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

grub fails to build on a 24.04 DE-based buildserver with:
```
16:32:50  dpkg: regarding grub2-build-deps_2.12-1ubuntu2_amd64.deb containing grub2-build-deps:
16:32:50   grub2-build-deps conflicts with libnvpair-dev
16:32:50    libzfslinux-dev provides libnvpair-dev and is present and installed.
16:32:50  
16:32:50  dpkg: error processing archive grub2-build-deps_2.12-1ubuntu2_amd64.deb (--unpack):
16:32:50   conflicting packages - not installing grub2-build-deps
16:32:50  Errors were encountered while processing:
16:32:50   grub2-build-deps_2.12-1ubuntu2_amd64.deb
16:32:50  mk-build-deps: dpkg --unpack failed
```
Example: https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/linux-pkg/job/os-upgrade/job/build-package/job/grub2/job/pre-push/59/console

The problem seems to be that `libnvpair-dev` is listed as a build conflict of grub2. But `libnvpair-dev` is also provided by `libzfslinux-dev` which is installed on DE-based buildservers.

</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Remove `libnvpair-dev` from the list of conflicting packages.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/linux-pkg/job/os-upgrade/job/build-package/job/grub2/job/pre-push/60/console
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
