### PR TITLE
DLPX-93834 LTS 24.04: incorrect running kernel after upgrade

### DIFF
--- a/util/grub.d/10_linux_zfs.in
+++ b/util/grub.d/10_linux_zfs.in
@@ -95,16 +95,12 @@ import_pools() {
 
 # List all the dataset with a root mountpoint
 get_root_datasets() {
-    local pools="$(zpool list | awk '{if (NR>1) print $1}')"
-
-    for p in ${pools}; do
-        local rel_pool_root=$(zpool get -H altroot ${p} | awk '{print $3}')
-        if [ "${rel_pool_root}" = "-" ]; then
-            rel_pool_root="/"
-        fi
-
-        zfs list -H -o name,canmount,mountpoint -t filesystem | grep -E '^'"${p}"'(\s|/[[:print:]]*\s)(on|noauto)\s'"${rel_pool_root}"'$' | awk '{print $1}'
-    done
+    #
+    # On Delphix, we generate the grub config only for the root filesystem. When switching root filesystems,
+    # our upgrade logic chroot's into the new root, and then runs grub-mkconfig. Thus, we can replace the
+    # implementation provided by upstream, with a much more simple command.
+    #
+    zfs list -H -o name /
 }
 
 # find if given datasets can be mounted for directory and return its path (snapshot or real path)
@@ -546,11 +542,14 @@ bootlist() {
         # get information from current root dataset
         boot_list="${boot_list}$(get_dataset_info "${dataset}" ${mntdir})\n"
 
+        #
+        # We don't ever boot from a snapshot on Delphix, so this logic has been commented out.
+        #
         # get information from snapshots of this root dataset
-        snapshots="$(zfs list -H -o name -t snapshot "${dataset}"|while read snapshot_dataset; do
-            get_dataset_info "${snapshot_dataset}" ${mntdir}
-        done)"
-        [ -n "${snapshots}" ] && boot_list="${boot_list}${snapshots}\n"
+        #snapshots="$(zfs list -H -o name -t snapshot "${dataset}"|while read snapshot_dataset; do
+        #    get_dataset_info "${snapshot_dataset}" ${mntdir}
+        #done)"
+        #[ -n "${snapshots}" ] && boot_list="${boot_list}${snapshots}\n"
     done
     echo "${boot_list}"
 }

--- a/util/grub.d/10_linux_zfs.in
+++ b/util/grub.d/10_linux_zfs.in
@@ -998,7 +998,6 @@ echo
                 fi
             fi
 
-            root=$(findmnt / | grep '^/' | awk '{print $2}' | sed 's@^[^/]*/@@')
             case "${section}" in
                 main)
                     title="${name}"
@@ -1006,7 +1005,7 @@ echo
                     main_dataset="${dataset}"
 
                     kernel_version=$(basename "${kernel}" | sed -e "s,^[^0-9]*-,,g")
-                    zfs_linux_entry 0 "${title}" "simple" "rpool/${root}" "${device}" "${initrd}" "${kernel}" "${kernel_version}"
+                    zfs_linux_entry 0 "${title}" "simple" "${dataset}" "${device}" "${initrd}" "${kernel}" "${kernel_version}"
                     at_least_one_entry=1
                 ;;
                 advanced)
@@ -1022,12 +1021,12 @@ echo
 
                     kernel_version=$(basename "${kernel}" | sed -e "s,^[^0-9]*-,,g")
                     title="$(gettext_printf "%s%s, with Linux %s" "${last_booted_kernel_marker}" "${name}" "${kernel_version}")"
-                    zfs_linux_entry 1 "${title}" "advanced" "rpool/${root}" "${device}" "${initrd}" "${kernel}" "${kernel_version}"
+                    zfs_linux_entry 1 "${title}" "advanced" "${dataset}" "${device}" "${initrd}" "${kernel}" "${kernel_version}"
 
                     GRUB_DISABLE_RECOVERY=${GRUB_DISABLE_RECOVERY:-}
                     if [ "${GRUB_DISABLE_RECOVERY}" != "true" ]; then
                         title="$(gettext_printf "%s%s, with Linux %s (%s)" "${last_booted_kernel_marker}" "${name}" "${kernel_version}" "$(gettext "${GRUB_RECOVERY_TITLE}")")"
-                        zfs_linux_entry 1 "${title}" "recovery" "rpool/${root}" "${device}" "${initrd}" "${kernel}" "${kernel_version}"
+                        zfs_linux_entry 1 "${title}" "recovery" "${dataset}" "${device}" "${initrd}" "${kernel}" "${kernel_version}"
                     fi
                     at_least_one_entry=1
                 ;;


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
The upstream grub-mkconfig logic is tailored to Ubuntu's ZFS on root layout, which conflicts with the upgrade logic and dataset layout used on the Delphix appliance.
</details>

<details open>
<summary><h2> Solution </h2></summary>
The solution is to modify the grub-mkconfig script, such that is adheres to the Delphix appliance's upgrade logic, and root dataset layout.
</details>


<details>
<summary><h2> Testing Done </h2></summary>

- I generated an upgrade container, upgraded it, and ran "grub-mkconfig" and manually inspected/verified the output.
- `git-ab-pre-push` is [here](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/10733/)

</details>
