### PR TITLE
DLPX-95141 Upgrade to 2025.4.0.2 failed with 'Internal Error" / "DelphixFatalException.java:46"

### DIFF
--- a/util/grub.d/10_linux_zfs.in
+++ b/util/grub.d/10_linux_zfs.in
@@ -948,40 +948,6 @@ generate_grub_menu() {
 
     print_menu_prologue
 
-    cat<<'EOF'
-function zsyshistorymenu {
-	# $1: root dataset (eg rpool/ROOT/ubuntu_2zhm07@autozsys_k56fr6)
-	# $2: boot device id (eg 411f29ce1557bfed)
-	# $3: initrd (eg /BOOT/ubuntu_2zhm07@autozsys_k56fr6/initrd.img-5.4.0-21-generic)
-	# $4: kernel (eg /BOOT/ubuntu_2zhm07@autozsys_k56fr6/vmlinuz-5.4.0-21-generic)
-	# $5: kernel_version (eg 5.4.0-21-generic)
-
-	set root_dataset="${1}"
-	set boot_device="${2}"
-	set initrd="${3}"
-	set kernel="${4}"
-	set kversion="${5}"
-
-EOF
-    boot_devices=$(echo "${menu_metadata}" | cut -d"$(printf '\t')" -f6 | sort -u)
-
-    title=$(gettext_printf "Revert system only")
-    zfs_linux_entry 1 "${title}" "simple" '${root_dataset}' '${boot_device}' '${initrd}' '${kernel}' '${kversion}' '' "${boot_devices}"
-
-    title="$(gettext_printf "Revert system and user data")"
-    zfs_linux_entry 1 "${title}" "simple" '${root_dataset}' '${boot_device}' '${initrd}' '${kernel}' '${kversion}' 'zsys-revert=userdata' "${boot_devices}"
-
-    GRUB_DISABLE_RECOVERY="${GRUB_DISABLE_RECOVERY:-}"
-    if [ "${GRUB_DISABLE_RECOVERY}" != "true" ]; then
-        title="$(gettext_printf "Revert system only (%s)" "$(gettext "${GRUB_RECOVERY_TITLE}")")"
-        zfs_linux_entry 1 "${title}" "recovery" '${root_dataset}' '${boot_device}' '${initrd}' '${kernel}' '${kversion}' '' "${boot_devices}"
-
-        title="$(gettext_printf "Revert system and user data (%s)" "$(gettext "${GRUB_RECOVERY_TITLE}")")"
-        zfs_linux_entry 1 "${title}" "recovery" '${root_dataset}' '${boot_device}' '${initrd}' '${kernel}' '${kversion}' 'zsys-revert=userdata' "${boot_devices}"
-    fi
-echo "}"
-echo
-
     # IFS is set to TAB (ASCII 0x09)
     echo "${menu_metadata}" |
     {

--- a/util/grub.d/10_linux_zfs.in
+++ b/util/grub.d/10_linux_zfs.in
@@ -1005,6 +1005,12 @@ generate_grub_menu() {
                     at_least_one_entry=1
                 ;;
                 history)
+                    #
+                    # On Delphix, we don't use zsys, so we should never have history entries.
+                    #
+                    echo "Unexpected history entry encountered, aborting." >&2
+                    exit 1
+
                     # Revert to a snapshot
                     # revert system, revert system and user data and associated recovery entries
                     if [ "${last_section}" != "${section}" ]; then


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
The following block of code in the `zfs_linux_entry` function is failing on illumos migrated systems:

```
    if [ -n "$boot_devices" ]; then
        for device in ${boot_devices}; do
            echo "${submenu_indentation}	if [ "${boot_device}" = "${device}" ]; then"
            echo "$(prepare_grub_to_access_device_cached "${device}" $(( submenu_level +1 )) )"
            echo "${submenu_indentation}	fi"
        done
    else
```

It's still not clear _why_ this block doesn't work on illumos migrated systems, but I've also noticed this logic is only called if `boot_devices` is non-empty. Further, we pass in a non-empty `boot_devices` only when populating the `zsyshistory` block in the grub configuration file. For Delphix systems, we don't use Ubuntu's `zsys` utility, so the `zsyshistory` block is completely unnecessary.
</details>

<details open>
<summary><h2> Solution </h2></summary>
The solution taken in this PR is to remove the logic that generates the `zsyshistory` block in the grub configuration file, which avoids calling the problematic logic on illumos migrated systems.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

- `git-ab-pre-push` (develop) is [here](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11939/) and [here](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11942/)

- `git-ab-pre-push` (patch) is [here](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11940/) and [here](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11944/)

- Testing on an illumos migrated system, upgrading from 5.3.9.0 to 2025.4.0.2 (without this fix, upgrade fails going to 2025.4.0.2).

</details>
